### PR TITLE
Fix path to require in lib/test/unit/collector/load.rb

### DIFF
--- a/lib/test/unit/collector/load.rb
+++ b/lib/test/unit/collector/load.rb
@@ -102,7 +102,7 @@ module Test
           return if @program_file == expanded_path.to_s
           add_load_path(expanded_path.dirname) do
             begin
-              require(path.to_s)
+              require(path.basename.to_s)
             rescue LoadError
               @require_failed_infos << {:path => expanded_path, :exception => $!}
             end


### PR DESCRIPTION
This fix make test succeed with ruby 1.9.x because ruby 1.9.x don't set current directory in load path.
