### PR TITLE
Use require_relative  if Ruby 1.9+

### DIFF
--- a/lib/test-unit.rb
+++ b/lib/test-unit.rb
@@ -1,1 +1,6 @@
-require "test/unit"
+if RUBY_VERSION < '1.9'
+  require "test/unit"
+else
+  require_relative "test/unit"
+end
+


### PR DESCRIPTION
This patch adjusts `test-unit.rb` to use  `require_relative 'test/unit'` when using Ruby 1.9+. For 1.9, this ensures another `test/unit` will never be loaded by mistake, e.g. the one shipped with Ruby. And it improves load time.
