### PR TITLE
Fix for issue #19: JRuby: TypeError: can't convert nil into Float

### DIFF
--- a/lib/test/unit/ui/console/testrunner.rb
+++ b/lib/test/unit/ui/console/testrunner.rb
@@ -201,6 +201,7 @@ module Test
             file = $1
             line_number = $2.to_i
             lines = @code_snippet_fetcher.fetch(file, line_number)
+            return if lines.empty?
             max_n = lines.collect {|n, line, attributes| n}.max
             digits = (Math.log10(max_n) + 1).truncate
             lines.each do |n, line, attributes|

--- a/test/test_jruby.rb
+++ b/test/test_jruby.rb
@@ -1,0 +1,31 @@
+require 'test/unit'
+require 'stringio'
+
+class TestJRuby < Test::Unit::TestCase
+  class TestCase < Test::Unit::TestCase
+    class << self
+      def suite
+        Test::Unit::TestSuite.new(name)
+      end
+    end
+
+    def test_java_exception_output
+      require 'java'
+      java.util.Vector.new -1
+    end
+  end
+
+  def test_java_exception_output
+    omit("Skipping test for JRuby") unless RUBY_PLATFORM =~ /java/
+
+    suite = TestCase.suite
+    suite << TestCase.new('test_java_exception_output')
+
+    output = StringIO.new
+    runner = Test::Unit::UI::Console::TestRunner.new(suite, :output => output)
+    result = runner.start
+
+    assert_equal 1, result.faults.size
+  end
+end
+


### PR DESCRIPTION
A test case and a fix for issue #19. The test case will be omitted if not on JRuby.
The fix is a trivial one-liner, breaking out of output_code_snippet when the source code is not accessible.
