### PR TITLE
fix for mocha 0.12 vs 2.5.1

### DIFF
--- a/lib/test/unit/testsuite.rb
+++ b/lib/test/unit/testsuite.rb
@@ -78,7 +78,7 @@ module Test
         @tests.each { |test| total_size += test.size }
         total_size
       end
-      
+
       def empty?
         tests.empty?
       end
@@ -88,7 +88,7 @@ module Test
       def to_s
         @name
       end
-      
+
       # It's handy to be able to compare TestSuite instances.
       def ==(other)
         return false unless(other.kind_of?(self.class))
@@ -114,6 +114,7 @@ module Test
         finished_is_yielded = false
         finished_object_is_yielded = false
         previous_event_name = nil
+        return unless test.respond_to?(:run) # missing from some irrelevant things in ActiveSupport v2
         test.run(result) do |event_name, *args|
           case previous_event_name
           when Test::Unit::TestCase::STARTED


### PR DESCRIPTION
otherwise fails with

```
/Users/mgrosser/.rvm/gems/ruby-1.9.3-p194/gems/test-unit-2.5.1/lib/test/unit/testsuite.rb:117:in `run_test': undefined method `responds_to?' for AccountDataCenterTest:Test::Unit::TestSuite (NoMethodError)
    from /Users/mgrosser/.rvm/gems/ruby-1.9.3-p194/gems/test-unit-2.5.1/lib/test/unit/testsuite.rb:53:in `run'
    from /Users/mgrosser/.rvm/gems/ruby-1.9.3-p194/gems/test-unit-2.5.1/lib/test/unit/ui/testrunnermediator.rb:93:in `run_suite'
    from /Users/mgrosser/.rvm/gems/ruby-1.9.3-p194/gems/test-unit-2.5.1/lib/test/unit/ui/testrunnermediator.rb:43:in `block in run'
    from /Users/mgrosser/.rvm/gems/ruby-1.9.3-p194/gems/test-unit-2.5.1/lib/test/unit/ui/testrunnermediator.rb:82:in `with_listener'
    from /Users/mgrosser/.rvm/gems/ruby-1.9.3-p194/gems/test-unit-2.5.1/lib/test/unit/ui/testrunnermediator.rb:39:in `run'
    from /Users/mgrosser/.rvm/gems/ruby-1.9.3-p194/gems/test-unit-2.5.1/lib/test/unit/ui/testrunner.rb:40:in `start_mediator'
    from /Users/mgrosser/.rvm/gems/ruby-1.9.3-p194/gems/test-unit-2.5.1/lib/test/unit/ui/testrunner.rb:25:in `start'
    from /Users/mgrosser/.rvm/gems/ruby-1.9.3-p194/gems/test-unit-2.5.1/lib/test/unit/ui/testrunnerutilities.rb:24:in `run'
    from /Users/mgrosser/.rvm/gems/ruby-1.9.3-p194/gems/test-unit-2.5.1/lib/test/unit/autorunner.rb:378:in `block in run'
    from /Users/mgrosser/.rvm/gems/ruby-1.9.3-p194/gems/test-unit-2.5.1/lib/test/unit/autorunner.rb:434:in `change_work_directory'
    from /Users/mgrosser/.rvm/gems/ruby-1.9.3-p194/gems/test-unit-2.5.1/lib/test/unit/autorunner.rb:377:in `run'
    from /Users/mgrosser/.rvm/gems/ruby-1.9.3-p194/gems/test-unit-2.5.1/lib/test/unit/autorunner.rb:58:in `run'
    from /Users/mgrosser/.rvm/gems/ruby-1.9.3-p194/gems/test-unit-2.5.1/lib/test/unit.rb:330:in `block in <top (required)>'
rake aborted!
```
