### PR TITLE
Make assert_(not_)match works on non-String object

### DIFF
--- a/lib/test/unit/assertions.rb
+++ b/lib/test/unit/assertions.rb
@@ -506,7 +506,7 @@ EOT
           full_message = build_message(message,
                                        "<?> expected to not match\n<?>.",
                                        regexp, string)
-          assert_block(full_message) { regexp !~ string }
+          assert_block(full_message) { string !~ regexp }
         end
       end
 

--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -680,7 +680,20 @@ EOM
           assert_match(/slin./, "string", "failed assert_match")
         }
       end
-      
+
+      def test_assert_match_on_non_string_object
+        object = Object.new
+        class << object
+          def =~(regexp)
+            "string" =~ regexp
+          end
+        end
+
+        check_nothing_fails do
+          assert_match(/string/, object)
+        end
+      end
+
       def test_assert_same
         thing = "thing"
         check_nothing_fails {
@@ -840,6 +853,19 @@ EOM
                     "</string/> expected to not match\n" +
                     "<\"string\">.") do
           assert_not_match(/string/, "string", "message")
+        end
+      end
+
+      def test_assert_not_match_on_non_string_object
+        object = Object.new
+        class << object
+          def =~(regexp)
+            "string" =~ regexp
+          end
+        end
+
+        check_nothing_fails do
+          assert_not_match(/sling/, object)
         end
       end
 


### PR DESCRIPTION
Previously, if we're trying to pass in a Object that implements `=~` method to `assert_not_match`, we would get `TypeError` because ruby will try to convert that object into a String. This can be fixed by swapping the operands and calling `=~` on the object instead.

I faced this error when I was trying to use `assert_not_match` on Mail::Body object, which is not a string but implement `=~` method.
