### PR TITLE
allow use of tests for inheritance in ActionController::TestCase

### DIFF
--- a/lib/test/unit/testcase.rb
+++ b/lib/test/unit/testcase.rb
@@ -106,6 +106,7 @@ module Test
         def inherited(sub_class) # :nodoc:
           require "test/unit"
           DESCENDANTS << sub_class
+          super
         end
 
         @@added_methods = {}


### PR DESCRIPTION
The goal is to allow:

``` ruby
class SignupControllerTest < ActionController::TestCase
  tests SignupController
end

class NewSignupControllerTest < SignupControllerTest
end
```

This gives the error: 

```
ActionController::NonInferrableControllerError: Unable to determine the controller to test from NewSignupControllerTest. You'll need to specify it using 'tests YourController' in your test case definition. This could mean that NewSignupControllerTest does not exist or it contains syntax errors
```

This currently will fail because `NewSignupControllerTest` doesn't have a controller defined.  
Currently, the workaround is to add the following to SignupControllerTest:

``` ruby
def self.inherited(klass)
  klass.tests ArtistController
  super
end
```

For reference, here's another similar issue with a similar solution:
http://weblog.jamisbuck.org/2011/6/7/sharing-the-inheritance-hierarchy
