### PR TITLE
Properly check $TERM for screen variants

### DIFF
--- a/lib/test/unit/ui/console/testrunner.rb
+++ b/lib/test/unit/ui/console/testrunner.rb
@@ -465,7 +465,7 @@ module Test
           def guess_color_availability
             return false unless @output.tty?
             case ENV["TERM"]
-            when /term(?:-(?:256)?color)?\z/, "screen"
+            when /(term|screen)(?:-(?:256)?color)?\z/
               true
             else
               return true if ENV["EMACS"] == "t"


### PR DESCRIPTION
Previously it would not recognize when $TERM was set to screen-256color
