### PR TITLE
more not asserts (+ flutes)

### DIFF
--- a/lib/test/unit/assertions.rb
+++ b/lib/test/unit/assertions.rb
@@ -520,6 +520,25 @@ EOT
         end
       end
 
+      public
+      def assert_not_operator(object1, operator, object2, message="")
+        _wrap_assertion do
+          full_message = build_message(nil, "<?>\ngiven as the operator for #assert_not_operator must be a Symbol or #respond_to\\?(:to_str).", operator)
+          assert_block(full_message){operator.kind_of?(Symbol) || operator.respond_to?(:to_str)}
+          full_message = build_message(message, <<EOT, object1, AssertionMessage.literal(operator), object2)
+<?> expected to not be
+?
+<?>.
+EOT
+          assert_block(full_message) { ! object1.__send__(operator, object2) }
+        end
+      end
+
+      # Just for minitest compatibility. :<
+      #
+      # @since 2.5.7
+      alias_method :refute_operator, :assert_not_operator
+
       ##
       # Passes if block does not raise an exception.
       #

--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -966,6 +966,18 @@ EOM
         }
       end
 
+      def test_assert_not_operator
+        check_nothing_fails {
+          assert_not_operator("thing", :==, "Thing", "message")
+        }
+        check_fail(%Q{<42>\ngiven as the operator for #assert_not_operator must be a Symbol or #respond_to?(:to_str).}) do
+          assert_not_operator("thing", 42, "message")
+        end
+        check_fail(%Q{message.\n<0> expected to not be\n==\n<0.0>.}) {
+          assert_not_operator(0, :==, 0.0, "message")
+        }
+      end
+
       def test_assert_respond_to
         check_nothing_fails {
           assert_respond_to("thing", :to_s, "message")


### PR DESCRIPTION
and some more mini-test compatibility. 
all these are aliased on latest Rails 4.0 to provide TU compatibility on top of MT, they do not use TU anymore but it should be easier to patch-in if we have all the expected assertions ...
