### PR TITLE
make license field parseable by license_finder

### DIFF
--- a/test-unit.gemspec
+++ b/test-unit.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   entries = readme.split(/^h2\.\s(.*)$/)
   description = clean_white_space.call(entries[entries.index("Description") + 1])
   spec.summary, spec.description, = description.split(/\n\n+/, 3)
-  spec.license = "Ruby's and PSFL (lib/test/unit/diff.rb)"
+  spec.license = ["Ruby", "PSFL"] # lib/test/unit/diff.rb is PSFL
   spec.files = ["README.textile", "TODO", "Rakefile"]
   spec.files += ["COPYING", "GPL", "LGPL", "PSFL"]
   spec.files += Dir.glob("{lib,sample}/**/*.rb")


### PR DESCRIPTION
I'm running our org though [organization license audit](https://github.com/grosser/organization_license_audit) and test-unit keeps popping up, how about we simplify it to `["Ruby", "PSDL"]` ?

@okkez @kou
