### PR TITLE
Only require power_assert if version > 1.8.7

### DIFF
--- a/lib/test/unit/assertions.rb
+++ b/lib/test/unit/assertions.rb
@@ -9,7 +9,7 @@ require 'test/unit/util/method-owner-finder'
 require 'test/unit/diff'
 
 begin
-  require 'power_assert'
+  require 'power_assert' if RUBY_VERSION > '1.8.7'
 rescue LoadError, SyntaxError
 end
 
@@ -132,7 +132,7 @@ module Test
           if block
             message = object if have_object
             if defined?(PowerAssert)
-              PowerAssert.start(block, assertion_method: __callee__) do |pa|
+              PowerAssert.start(block, :assertion_method => __callee__) do |pa|
                 pa_message = AssertionMessage.delayed_literal(&pa.message_proc)
                 assertion_message = build_message(message, "?", pa_message)
                 assert_block(assertion_message) do


### PR DESCRIPTION
The power_assert gem uses hash syntax that is not valid in Ruby version 1.8.7

I've made two changes:
1. Only require the power_assert gem if Ruby version is > 1.8.7
2. Stick to hash syntax valid in 1.8.7, as test-unit should support back to this version. I realize that line 135 won't even run in version 1.8.7 because PowerAssert wouldn't be defined, but syntax should be consistent, until the test-unit gem says it doesn't support 1.8.7.
