### PR TITLE
Remove backtrace filters for JRuby and Rubinius.

### DIFF
--- a/lib/test/unit/util/backtracefilter.rb
+++ b/lib/test/unit/util/backtracefilter.rb
@@ -23,21 +23,13 @@ module Test
             split_entry[-1].sub(TESTUNIT_RB_FILE, '') == split_prefix[-1]
           end
 
-          jruby_internal_p = lambda do |entry|
-            entry.start_with?("org/jruby/")
-          end
-
-          rubinius_internal_p = lambda do |entry|
-            entry.start_with?("kernel/")
-          end
-
           found_prefix = false
           new_backtrace = backtrace.reverse.reject do |entry|
             if test_unit_internal_p.call(entry)
               found_prefix = true
               true
             elsif found_prefix
-              jruby_internal_p.call(entry) or rubinius_internal_p.call(entry)
+              false
             else
               true
             end


### PR DESCRIPTION
Unlike MRI, JRuby and Rubinius often show internal methods in
backtraces. For example, an Array#each backtrace in each:

```
$ rvm ruby-2.1.2,jruby-1.7.16,rbx do ruby -e "[1].each { raise }"
-e:1:in `block in <main>': unhandled exception
    from -e:1:in `each'
    from -e:1:in `<main>'
RuntimeError: No current exception
  (root) at -e:1
    each at org/jruby/RubyArray.java:1613
  (root) at -e:1
An exception occurred evaluating command line code:

    No current exception (RuntimeError)

Backtrace:

                     { } in Object#__script__ at -e:1
                                   Array#each at kernel/bootstrap/array.rb:76
                     { } in Object#__script__ at -e:1
  Rubinius::BlockEnvironment#call_on_instance at kernel/common/block_environment.rb:53
                Kernel(Rubinius::Loader)#eval at kernel/common/eval.rb:176
                       Rubinius::Loader#evals at kernel/loader.rb:616
                        Rubinius::Loader#main at kernel/loader.rb:824
```

The internals lines here are "RubyArray.java" for JRuby and the
"kernel/*" lines for Rubinius. They may look like they should be
filtered out to get a clean backtrace, but in both cases that
removes vital information.

Note that JRuby's trace is three lines, just like MRI, but we
show the actual core class method being called from Ruby where MRI
can only show the caller's file and line number. We feel this is
an advantage in JRuby, but more importantly filtering this trace
prevents a user from knowing the call went through Array#each.

A similar argument can be made for Rubinius; you can't see the
core method that caused an exception and you can't see any
intervening core methods that might be on the stack.

For these reasons, I believe this filtering should be removed.
This commit attempts to do that, but I wasn't quite sure of the
"found_prefix" flag set while rejecting backtrace elements. Please
review my change.
