### PR TITLE
Output code snippet adjust line to assert in block

### DIFF
--- a/lib/test/unit/fault-location-detector.rb
+++ b/lib/test/unit/fault-location-detector.rb
@@ -66,7 +66,7 @@ module Test
       end
 
       def target_method?(method_name)
-        @fault_method_name == method_name
+        @fault_method_name == method_name.split(/\s+/).last
       end
 
       def guess_indent_level(line)


### PR DESCRIPTION
Output code snippet only show bottom method call line when assert fault in block.

like this.

``` ruby
$ cat sample.rb
require 'test/unit'

class TestSample < Test::Unit::TestCase
  def foo
    yield
  end

  def bar
    yield
  end

  def test_in_block
    foo do
      bar do
        assert_false(false)
        assert_false(true)
      end
    end
  end

  def test_in_proc
    Proc.new {
      assert_false(false)
      assert_false(true)
    }.call
  end
end
```

```
$ bundle exec ruby sample.rb
Loaded suite sample
Started
F
===============================================================================
Failure:
  <false> expected but was
  <true>
test_in_block(TestSample)
sample.rb:16:in `block (2 levels) in test_in_block'
sample.rb:9:in `bar'
sample.rb:14:in `block in test_in_block'
sample.rb:5:in `foo'
sample.rb:13:in `test_in_block'
     10:   end
     11:
     12:   def test_in_block
  => 13:     foo do
     14:       bar do
     15:         assert_false(false)
     16:         assert_false(true)
===============================================================================
F
===============================================================================
Failure:
  <false> expected but was
  <true>
test_in_proc(TestSample)
sample.rb:24:in `block in test_in_proc'
sample.rb:25:in `call'
sample.rb:25:in `test_in_proc'
     22:     Proc.new {
     23:       assert_false(false)
     24:       assert_false(true)
  => 25:     }.call
     26:   end
     27: end
===============================================================================


Finished in 0.004278 seconds.

2 tests, 4 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
0% passed

467.51 tests/s, 935.02 assertions/s
```

But I think, Most user want to show like that.

```
$ bundle exec ruby sample.rb
Loaded suite sample
Started
F
===============================================================================
Failure:
  <false> expected but was
  <true>
test_in_block(TestSample)
sample.rb:16:in `block (2 levels) in test_in_block'
     13:     foo do
     14:       bar do
     15:         assert_false(false)
  => 16:         assert_false(true)
     17:       end
     18:     end
     19:   end
sample.rb:9:in `bar'
sample.rb:14:in `block in test_in_block'
sample.rb:5:in `foo'
sample.rb:13:in `test_in_block'
===============================================================================
F
===============================================================================
Failure:
  <false> expected but was
  <true>
test_in_proc(TestSample)
sample.rb:24:in `block in test_in_proc'
     21:   def test_in_proc
     22:     Proc.new {
     23:       assert_false(false)
  => 24:       assert_false(true)
     25:     }.call
     26:   end
     27: end
sample.rb:25:in `call'
sample.rb:25:in `test_in_proc'
===============================================================================


Finished in 0.004278 seconds.

2 tests, 4 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
0% passed

467.51 tests/s, 935.02 assertions/s
```

This is patched output.

---

Now, Output code snippet is only show one time in (lib/test/unit/ui/console/testrunner.rb). This is reasone why I fix assert_detect.
