### PR TITLE
Only detect encoding if the Ruby supports it

### DIFF
--- a/lib/test/unit/code-snippet-fetcher.rb
+++ b/lib/test/unit/code-snippet-fetcher.rb
@@ -41,6 +41,7 @@ module Test
       end
 
       def detect_encoding(first_line)
+        return nil unless first_line.respond_to?(:ascii_only?)
         return nil unless first_line.ascii_only?
         if /\b(?:en)?coding[:=]\s*([a-z\d_-]+)/i =~ first_line
           begin


### PR DESCRIPTION
Fixed #88 introduced by #87.
