### PR TITLE
Use --no-document option instead of --no-rdoc and --no-ri option

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - ruby --version
   - gem --version
-  - gem install bundler --quiet --no-ri --no-rdoc
+  - gem install bundler --quiet --no-document
   - bundler --version
   - bundle install
 


### PR DESCRIPTION
The reason for this change is that --no-rdoc and --no-ri option is deprecated.

## Also see

* [gem install(command reference)](http://guides.rubygems.org/command-reference/#gem-install)
* [gemrcの--no-riと--no-rdoc、deprecatedなoptionなのでみなおしたほうがいいかもですよ](http://qiita.com/kei_q/items/d13235157fcfc435489d)