### PR TITLE
Fix the warnings from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
@@ -10,5 +11,5 @@ matrix:
     - rvm: rbx-2
     - rvm: jruby
 notifications:
-  recipients:
+  email:
     - test-unit-commit@googlegroups.com


### PR DESCRIPTION
If you execute `travis lint` command, the following warnings is displayed.

Warnings for .travis.yml:
[x] value for notifications section is empty, dropping
[x] missing key language, defaulting to ruby
[x] in notifications section: unexpected key recipients, dropping