### PR TITLE
set both external and internal encoding to prevent conversion

### DIFF
--- a/lib/test/unit/code-snippet-fetcher.rb
+++ b/lib/test/unit/code-snippet-fetcher.rb
@@ -32,7 +32,7 @@ module Test
           encoding = detect_encoding(first_line)
           if encoding
             first_line.force_encoding(encoding)
-            file.set_encoding(encoding)
+            file.set_encoding(encoding, encoding)
           end
           lines << first_line
           lines.concat(file.readlines)


### PR DESCRIPTION
If Encoding.default_internal is set, only external encoding set
cause encoding conversion, which may fail.