### PR TITLE
Filter backtrace of power_assert

### DIFF
--- a/test/util/test_backtracefilter.rb
+++ b/test/util/test_backtracefilter.rb
@@ -37,5 +37,16 @@ backtrace = [%q{tc_thing.rb:4:in 'a'},
     def test_nil_backtrace
       assert_equal(["No backtrace"], filter_backtrace(nil))
     end
+
+    def test_power_assert_backtrace
+      omit('test for power_assert') unless defined?(PowerAssert)
+      blk = Proc.new {caller.find {|i| /power_assert.*in \`start\'/ =~ i}}
+      PowerAssert.start(blk) do |pa|
+        backtrace = [pa.yield,
+          %q{tc_thing.rb:4:in 'a'},
+          %q{tc_thing.rb:4:in 'test_stuff'}]
+        assert_equal(backtrace[1..2], filter_backtrace(backtrace))
+      end
+    end
   end
 end


### PR DESCRIPTION
### Before
~~~
test_power_assert(T)
/usr/local/ruby-2.2/lib/ruby/gems/2.2.0/gems/power_assert-0.2.2/lib/power_assert.rb:29:in `start'
t.rb:5:in `test_power_assert'
     2:
     3: class T < Test::Unit::TestCase
     4:   def test_power_assert
  => 5:     assert { "a".empty? }
     6:   end
     7: end
~~~

### After
~~~
test_power_assert(T)
t.rb:5:in `test_power_assert'
     2:
     3: class T < Test::Unit::TestCase
     4:   def test_power_assert
  => 5:     assert { "a".empty? }
     6:   end
     7: end
~~~
