### PR TITLE
Fix conflict with test-unit-power_assert

### DIFF
--- a/lib/test/unit/util/backtracefilter.rb
+++ b/lib/test/unit/util/backtracefilter.rb
@@ -12,8 +12,8 @@ module Test
         TESTUNIT_RB_FILE = /\.rb\Z/
 
         POWERASSERT_PREFIX =
-          defined?(PowerAssert) ?
-            PowerAssert.method(:start).source_location[0].split(TESTUNIT_FILE_SEPARATORS)[0..-2] :
+          defined?(::PowerAssert) ?
+            ::PowerAssert.method(:start).source_location[0].split(TESTUNIT_FILE_SEPARATORS)[0..-2] :
             nil
 
         module_function


### PR DESCRIPTION
test-unit-power_assert defines Test::Unit::PowerAssert.
So when test-unit-power_assert is required before test-unit,
`PowerAssert` in Test::Unit::Util::BacktraceFilter refers to
Test::Unit::PowerAssert and it causes a following error.

~~~
$ ruby -rtest/unit/power_assert -rtest/unit -eexit
.../test/unit/util/backtracefilter.rb:16:in `method': undefined method `start' for class `Module' (NameError)
~~~