### PR TITLE
Enable to use color on urxvt

### DIFF
--- a/lib/test/unit/ui/console/testrunner.rb
+++ b/lib/test/unit/ui/console/testrunner.rb
@@ -488,6 +488,7 @@ module Test
           def guess_color_availability
             return false unless @output.tty?
             return true if windows? and ruby_2_0_or_later?
+            return true if ColorScheme::available_colors
             case ENV["TERM"]
             when /(?:term|screen)(?:-(?:256)?color)?\z/
               true


### PR DESCRIPTION
Dear Maintainer of test-unit2:

(If you can read Japanese,
Japanese version of this text is prepared after english version.)

I propose revision about the treatment of the terminal
which applies a color function.  

Problem:
The present test-unit2 can use color automatically with the terminals
when the environment variable 'TERM' is 'gnome-termina' or  finishes with 'term-color'.
I uses Ubuntu 16.04 and rxvt-unicode terminal emulator.
Although the terminal can treat a color, the test-unit does not recognize a colorized terminal.
( My $TERM is 'rxvt-unicode' and $COLORTERM is '1'.)

The current version can use color even on rxvt-unicode
if the environment variable 'COLORTERM' was set as 'gnome-terminal'.
But I feel not good because 'rxvt' is not 'gnome-terminal'.

Modification:
Although Test::Unit::ColorScheme#available_colors in lib/test/unit/color-scheme.rb
returns true even on rxvt-unicode,
Test::Unit::UI::Console::TestRunner#guess_color_availability
in lib/test/unit/ui/console/testrunner.rb returns false.

The result report becomes colorized
by insertion of the code following between 490-491 lines of lib/test/unit/ui/console/testrunner.rb
to use the results of Test::Unit::ColorScheme#available_colors.

  return true if ColorScheme::available_colors

  'rake test' passed without errors and failures.

Thank you in advance for your consideration.  

Ippei Kishida(Ippei)
------------------------------------------------------------
岸田逸平と申します。

test-unit2 を便利に利用させて頂いています。
カラー機能を適用する端末の扱いについて修正を提案します。

問題点：
  現在の test-unit2 では環境変数 TERM が term-color で終わるものは自動的に
  カラー化端末だと判断してカラー化してくれますが、
  それ以外では自動的にはカラーとして扱ってくれません。
  私は Ubuntu 16.04 で rxvt-unicode を使用していますが、
  これはカラーが扱える端末でありながら、
  test-unit2 はそのように認識してくれません。
    ( $TERM は rxvt-unicode , $COLORTERM は 1 と設定しています。)
  システム 側で何とかしようとしましたが、
  Ubuntu の /lib/terminfo には以下が入っているものの term-color
  で終わるものがありません。

    rxvt
    rxvt-basic
    rxvt-m
    rxvt-unicode

  環境変数 COLORTERM を gnome-terminal などに設定しておくとカラー化しますが、
  gnome-terminal ではない rxvt でこのように設定しておくのは
  少々気持ち悪い気がします。

修正案：
  lib/test/unit/color-scheme.rb 内のメソッド
  Test::Unit::ColorScheme#available_colors
  は rxvt-unicode でも真に判定されますが、
  lib/test/unit/ui/console/testrunner.rb  の
  Test::Unit::UI::Console::TestRunner#guess_color_availability
  で偽と判定されるようです。
  後者のメソッド内で
  Test::Unit::ColorScheme#available_colors の結果を返すようにしたら
  rxvt-unicode でも結果レポートのカラー化ができました。
  メソッド内のどこに置くべきかは少し判断つきかねましたが、
  とりあえず 490-491 行の間に以下を挿入してみました。

  return true if ColorScheme::available_colors

  rake test は問題なく通過するようです。

本家への反映、および必要ならメンテナ様の方での修正をご検討頂けたら幸いです。

岸田逸平(いっぺい)