### PR TITLE
Migrate to Travis' new container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
+sudo: false
+cache:
+  - bundler
 rvm:
   - 1.9.3
   - 2.0.0


### PR DESCRIPTION
Travis says it is faster than legacy infrastructure.
See for detail: https://docs.travis-ci.com/user/migrating-from-legacy/