### PR TITLE
Swapped "expected" and "actual" display order in fail message for assert_same

### DIFF
--- a/lib/test/unit/assertions.rb
+++ b/lib/test/unit/assertions.rb
@@ -551,9 +551,9 @@ EOT
       #   o = Object.new
       #   assert_same o, o
       def assert_same(expected, actual, message="")
-        full_message = build_message(message, <<EOT, expected, expected.__id__, actual, actual.__id__)
+        full_message = build_message(message, <<EOT, actual, actual.__id__, expected, expected.__id__)
 <?>
-with id <?> expected to be equal\\? to
+with id <?> was expected to be equal\\? to
 <?>
 with id <?>.
 EOT

--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -823,7 +823,7 @@ EOM
         check_fail(%Q{<"thing">\nwith id <#{thing2.__id__}> was expected to be equal? to\n<"thing">\nwith id <#{thing.__id__}>.}) {
           assert_same(thing, thing2)
         }
-        check_fail(%Q{failed assert_same.\n<"thing">\nwith id <#{thing.__id__}> expected to be equal? to\n<"thing">\nwith id <#{thing2.__id__}>.}) {
+        check_fail(%Q{failed assert_same.\n<"thing">\nwith id <#{thing2.__id__}> was expected to be equal? to\n<"thing">\nwith id <#{thing.__id__}>.}) {
           assert_same(thing, thing2, "failed assert_same")
         }
       end

--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -820,7 +820,7 @@ EOM
           assert_same(thing, thing, "successful assert_same")
         }
         thing2 = "thing"
-        check_fail(%Q{<"thing">\nwith id <#{thing.__id__}> was expected to be equal? to\n<"thing">\nwith id <#{thing2.__id__}>.}) {
+        check_fail(%Q{<"thing">\nwith id <#{thing2.__id__}> was expected to be equal? to\n<"thing">\nwith id <#{thing.__id__}>.}) {
           assert_same(thing, thing2)
         }
         check_fail(%Q{failed assert_same.\n<"thing">\nwith id <#{thing.__id__}> expected to be equal? to\n<"thing">\nwith id <#{thing2.__id__}>.}) {

--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -820,7 +820,7 @@ EOM
           assert_same(thing, thing, "successful assert_same")
         }
         thing2 = "thing"
-        check_fail(%Q{<"thing">\nwith id <#{thing.__id__}> expected to be equal? to\n<"thing">\nwith id <#{thing2.__id__}>.}) {
+        check_fail(%Q{<"thing">\nwith id <#{thing.__id__}> was expected to be equal? to\n<"thing">\nwith id <#{thing2.__id__}>.}) {
           assert_same(thing, thing2)
         }
         check_fail(%Q{failed assert_same.\n<"thing">\nwith id <#{thing.__id__}> expected to be equal? to\n<"thing">\nwith id <#{thing2.__id__}>.}) {


### PR DESCRIPTION
Also changed voice to past tense