### PR TITLE
--name does not detect test when data label contains parenthesis

### DIFF
--- a/lib/test/unit/autorunner.rb
+++ b/lib/test/unit/autorunner.rb
@@ -246,7 +246,7 @@ module Test
             name = (%r{\A/(.*)/\Z} =~ name ? Regexp.new($1) : name)
             @filters << lambda do |test|
               return true if name === test.method_name
-              test_name_without_class_name = test.name.gsub(/\(.+?\)\z/, "")
+              test_name_without_class_name = test.name.gsub(/\([^\(]+\)\z/, "")
               if test_name_without_class_name != test.method_name
                 return true if name === test_name_without_class_name
               end


### PR DESCRIPTION
Steps to reproduce:
~~~
$ cat test.rb
require 'test/unit'

class T < Test::Unit::TestCase
  data("()" => [0, 0])
  def test_t(*)
  end
end

$ ruby test.rb --name 'test_t[()]'
# Expected
Loaded suite t
Started
.

Finished in 0.000529415 seconds.
--------------------------------------------------------------------------------------
1 tests, 0 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------
1888.88 tests/s, 0.00 assertions/s
# Actual
(none)
~~~
