### PR TITLE
doc: Add `attribute` document

### DIFF
--- a/lib/test/unit/attribute.rb
+++ b/lib/test/unit/attribute.rb
@@ -49,6 +49,69 @@ module Test
           @current_attributes = kept_attributes
         end
 
+        # Set an attribute to test methods.
+        #
+        # @overload attribute(name, value)
+        #   @example
+        #     attribute :speed, :slow
+        #     def test_my_slow_method
+        #       self[:speed] # => :slow
+        #     end
+        #
+        #   @param [Object] name the attribute name
+        #   @param [Object] value the attribute value
+        #   @return [void]
+        #
+        # @overload attribute(name, value, *method_names)
+        #   @example
+        #     def test_my_slow_method1
+        #       self[:speed] # => :slow
+        #     end
+        #
+        #     attribute :speed, :slow, :test_my_slow_method1, :test_my_slow_method2
+        #
+        #     def test_my_slow_method2
+        #       self[:speed] # => :slow
+        #     end
+        #
+        #   @param [Object] name the attribute name
+        #   @param [Object] value the attribute value
+        #   @param [Array<Symbol, String>] method_names the test method names set the attribute
+        #   @return [void]
+        #
+        # @overload attribute(name, value, options)
+        #   @example
+        #     attribute :speed, :slow, keep: true
+        #     def test_my_slow_method1
+        #       self[:speed] # => :slow
+        #     end
+        #
+        #     def test_my_slow_method2
+        #       self[:speed] # => :slow
+        #     end
+        #
+        #   @param [Object] name the attribute name
+        #   @param [Object] value the attribute value
+        #   @option options [Boolean] :keep whether or not to set attribute to following test methods
+        #   @return [void]
+        #
+        # @overload attribute(name, value, options, *method_names)
+        #   @example
+        #     def test_my_slow_method1
+        #       self[:speed] # => :slow
+        #     end
+        #
+        #     attribute :speed, :slow, {keep: true}, :test_my_slow_method1
+        #
+        #     def test_my_slow_method2
+        #       self[:speed] # => nil
+        #     end
+        #
+        #   @param [Object] name the attribute name
+        #   @param [Object] value the attribute value
+        #   @param [Hash] options ignored
+        #   @param [Array<Symbol, String>] method_names the test method names set the attribute
+        #   @return [void]
         def attribute(name, value, options={}, *method_names)
           unless options.is_a?(Hash)
             method_names << options

--- a/lib/test/unit/testcase.rb
+++ b/lib/test/unit/testcase.rb
@@ -82,6 +82,25 @@ module Test
     # 1. cleanup
     # 1. teardown
     # 1. shutdown
+    #
+    # You can set an attribute to each test.
+    #
+    # Example:
+    #
+    #     class TestMyClass < Test::Unit::TestCase
+    #       attribute :speed, :fast
+    #       def test_my_fast_method
+    #         # You can get the attribute via `self[]`
+    #         self[:speed] # => :fast
+    #         ...
+    #       end
+    #
+    #       attribute :speed, :slow
+    #       def test_my_slow_method
+    #         self[:speed] # => :slow
+    #         ...
+    #       end
+    #     end
     class TestCase
       include Attribute
       include Fixture


### PR DESCRIPTION
Context: #142

----------

### Another Information

I just noticed following behavior when I tried to write documentation:

```ruby
require 'test-unit'

class AttrTest < Test::Unit::TestCase
  def test_slow_method1
   p self[:speed] # => :slow
  end

  attribute :speed, :slow, {keep: true}, :test_slow_method1

  def test_slow_method2
   p self[:speed] # => nil
  end
end
```

Is this intentional?