### PR TITLE
Fix missing link in doc/reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ writing tests, checking results and automated testing in Ruby.
 
 ## How To
 
-* [How To](doc/text/how-to.md) (link for GitHub)
+* [How To](https://github.com/test-unit/test-unit/blob/master/doc/text/how-to.md) (link for GitHub)
 * {file:doc/text/how-to.md How To} (link for YARD)
 
 ## Install


### PR DESCRIPTION
http://test-unit.github.io/test-unit/en/index.html  
`How To (link for GitHub)` link is relative path.
```
<a href="doc/text/how-to.md">How To</a>
```
