### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+# To use rbx environment.
+dist: trusty
 sudo: false
 cache:
   - bundler
@@ -7,16 +9,19 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-  - 2.3.0
-  - 2.4.0
-  - rbx-2
+  - 2.3.4
+  - 2.4.1
+  - ruby-head
+  - rbx-3
   - jruby
 before_install:
   - gem update bundler
 matrix:
   allow_failures:
-    - rvm: rbx-2
+    - rvm: ruby-head
+    - rvm: rbx-3
     - rvm: jruby
+  fast_finish: true
 notifications:
   email:
     - test-unit-commit@googlegroups.com


### PR DESCRIPTION
Hello,
I updated `.travis.yml`.

I updated Rubies to latest version in `.travis.yml`.

I also added ruby-head as allow_failures.
I think this is useful.
Because we can support the next version Ruby as faster.

We can see this kind of logic in `rspec`, `cucumber`, `rails` and etc.
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml
https://github.com/rails/rails/blob/master/.travis.yml

I added "dist: trusty" to use rbx environment.
Because rbx environment is available for only Ubuntu Trusty version.
It is not available for default Ubuntu older version.
