### PR TITLE
Get tests passing with frozen-string-literals enabled.

### DIFF
--- a/lib/test/unit/assertions.rb
+++ b/lib/test/unit/assertions.rb
@@ -152,9 +152,9 @@ module Test
             when AssertionMessage
               assertion_message = message
             else
-              error_message = "assertion message must be String, Proc or "
-              error_message << "#{AssertionMessage}: "
-              error_message << "<#{message.inspect}>(<#{message.class}>)"
+              error_message = "assertion message must be String, Proc or " \
+                              "#{AssertionMessage}: " \
+                              "<#{message.inspect}>(<#{message.class}>)"
               raise ArgumentError, error_message, filter_backtrace(caller)
             end
             assertion_message ||= build_message(message,
@@ -191,9 +191,9 @@ module Test
           when AssertionMessage
             assertion_message = message
           else
-            error_message = "assertion message must be String, Proc or "
-            error_message << "#{AssertionMessage}: "
-            error_message << "<#{message.inspect}>(<#{message.class}>)"
+            error_message = "assertion message must be String, Proc or " \
+                            "#{AssertionMessage}: " \
+                            "<#{message.inspect}>(<#{message.class}>)"
             raise ArgumentError, error_message, filter_backtrace(caller)
           end
           assert_block("refute should not be called with a block.") do
@@ -326,7 +326,7 @@ EOT
           else
             klasses = [klass]
           end
-          assert_block("The first parameter to assert_instance_of should be " +
+          assert_block("The first parameter to assert_instance_of should be " \
                        "a Class or an Array of Class.") do
             klasses.all? {|k| k.is_a?(Class)}
           end
@@ -362,7 +362,7 @@ EOT
           else
             klasses = [klass]
           end
-          assert_block("The first parameter to assert_not_instance_of should be " <<
+          assert_block("The first parameter to assert_not_instance_of should be " +
                        "a Class or an Array of Class.") do
             klasses.all? {|k| k.is_a?(Class)}
           end
@@ -925,12 +925,12 @@ EOT
       def _assert_in_delta_message(expected_float, actual_float, delta,
                                    message, options={})
         if options[:negative_assertion]
-          format = <<-EOT
+          format = <<-EOT.dup
 <?> -/+ <?> was expected to not include
 <?>.
 EOT
         else
-          format = <<-EOT
+          format = <<-EOT.dup
 <?> -/+ <?> was expected to include
 <?>.
 EOT
@@ -1064,12 +1064,12 @@ EOT
         delta = normalized_expected * normalized_epsilon
 
         if options[:negative_assertion]
-          format = <<-EOT
+          format = <<-EOT.dup
 <?> -/+ (<?> * <?>)[?] was expected to not include
 <?>.
 EOT
         else
-          format = <<-EOT
+          format = <<-EOT.dup
 <?> -/+ (<?> * <?>)[?] was expected to include
 <?>.
 EOT
@@ -1768,14 +1768,14 @@ EOT
             delayed_literal do
               from, to = prepare_for_diff(from, to)
 
-              diff = "" if from.nil? or to.nil?
+              diff = "".dup if from.nil? or to.nil?
               diff ||= Diff.readable(from, to)
               if /^[-+]/ !~ diff
-                diff = ""
+                diff = "".dup
               elsif /^[ ?]/ =~ diff or /(?:.*\n){2,}/ =~ diff
-                diff = "\n\ndiff:\n#{diff}"
+                diff = "\n\ndiff:\n#{diff}".dup
               else
-                diff = ""
+                diff = "".dup
               end
 
               if Diff.need_fold?(diff)
@@ -1796,7 +1796,7 @@ EOT
               begin
                 require 'pp' unless defined?(PP)
                 begin
-                  return PP.pp(inspector, '').chomp
+                  return PP.pp(inspector, ''.dup).chomp
                 rescue NameError
                 end
               rescue LoadError
@@ -2042,7 +2042,7 @@ EOT
           def result(parameters)
             raise "The number of parameters does not match the number of substitutions." if(parameters.size != count)
             params = parameters.dup
-            expanded_template = ""
+            expanded_template = "".dup
             @parts.each do |part|
               if part == '?'
                 encoding_safe_concat(expanded_template, params.shift)

--- a/lib/test/unit/autorunner.rb
+++ b/lib/test/unit/autorunner.rb
@@ -188,8 +188,8 @@ module Test
 
       def options
         @options ||= OptionParser.new do |o|
-          o.banner = "Test::Unit automatic runner."
-          o.banner << "\nUsage: #{$0} [options] [-- untouched arguments]"
+          o.banner = "Test::Unit automatic runner." \
+                     "\nUsage: #{$0} [options] [-- untouched arguments]"
 
           o.on("-r", "--runner=RUNNER", RUNNERS,
                "Use the given RUNNER.",

--- a/lib/test/unit/diff.rb
+++ b/lib/test/unit/diff.rb
@@ -450,7 +450,7 @@ module Test
 
         def tag(mark, contents)
           contents.each do |content|
-            @result << "#{mark}#{content}"
+            @result << "#{mark}#{content}".dup
           end
         end
 
@@ -569,8 +569,8 @@ module Test
         end
 
         def diff_line(from_line, to_line)
-          from_tags = ""
-          to_tags = ""
+          from_tags = "".dup
+          to_tags = "".dup
           from_line, to_line, _operations = line_operations(from_line, to_line)
           _operations.each do |tag, from_start, from_end, to_start, to_end|
             from_width = compute_width(from_line, from_start, from_end)

--- a/lib/test/unit/ui/emacs/testrunner.rb
+++ b/lib/test/unit/ui/emacs/testrunner.rb
@@ -29,18 +29,14 @@ module Test
             else
               location_display = "\n" + failure.location.join("\n")
             end
-            result = "#{failure.label}:\n"
-            result << "#{failure.test_name}#{location_display}:\n"
-            result << failure.message
-            result
+            "#{failure.label}:\n" \
+            "#{failure.test_name}#{location_display}:\n#{failure.message}"
           end
 
           def format_fault_error(error)
-            result = "#{error.label}:\n"
-            result << "#{error.test_name}:\n"
-            result << "#{error.message}\n"
-            result << error.backtrace.join("\n")
-            result
+            "#{error.label}:\n" \
+            "#{error.test_name}:\n" \
+            "#{error.message}\n#{error.backtrace.join("\n")}"
           end
         end
       end

--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -819,7 +819,7 @@ EOM
         check_nothing_fails {
           assert_same(thing, thing, "successful assert_same")
         }
-        thing2 = "thing"
+        thing2 = "thing".dup
         check_fail(%Q{<"thing">\nwith id <#{thing.__id__}> was expected to be equal? to\n<"thing">\nwith id <#{thing2.__id__}>.}) {
           assert_same(thing, thing2)
         }
@@ -906,7 +906,7 @@ EOM
 
       def test_assert_not_same
         thing = "thing"
-        thing2 = "thing"
+        thing2 = "thing".dup
         check_nothing_fails {
           assert_not_same(thing, thing2)
         }


### PR DESCRIPTION
These changes ensure that all string literals can be frozen (as per the optional feature in MRI 2.3 and onwards). I would recommend adding the following to your `.travis.yml` file to ensure regressions aren't introduced:

```yml
before_script:
- if (ruby -e "exit RUBY_VERSION.to_f >= 2.4"); then export RUBYOPT="--enable-frozen-string-literal"; fi; echo $RUBYOPT
```

This will add the flag when the tests are run on MRI 2.4 or newer (while the feature was introduced in 2.3, it doesn't seem to work reliably until 2.4). Please note: tests will currently fail when this flag is set unless `gettext` is also updated (I will submit a PR there too).