### PR TITLE
Add source code link to gemspec

### DIFF
--- a/test-unit.gemspec
+++ b/test-unit.gemspec
@@ -44,6 +44,10 @@ Gem::Specification.new do |spec|
   spec.files += Dir.glob("doc/text/**/*.*")
   spec.test_files += Dir.glob("test/**/*")
 
+  spec.metadata = {
+    'source_code_uri' => 'https://github.com/test-unit/test-unit'
+  }
+
   spec.add_runtime_dependency("power_assert")
   spec.add_development_dependency("bundler")
   spec.add_development_dependency("rake")


### PR DESCRIPTION
Makes it easy to programatically find the source code and changelog for `test-unit`, using the rubygems API. More details on the direction of travel for gemspecs is [here](https://github.com/rubygems/rubygems.org/issues/1127) and [here](https://github.com/rubygems/rubygems.org/pull/1234), and the current state is [here](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/specification.rb).

(My interest in this is so that [Dependabot](https://dependabot.com) can find a link to the `test-unit` source code when it creates PRs. Without that link, we generate PRs like [this one](https://github.com/greysteil/onebody/pull/20), rather than PRs like [this one](https://github.com/greysteil/onebody/pull/12).)