### PR TITLE
Use rdoc markup to format reference manual correctly

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,7 +1,6 @@
 --title test-unit
 --readme README.md
---markup markdown
---markup-provider kramdown
+--markup rdoc
 --files doc/text/**/*.*
 --output-dir doc/reference/en
 --charset utf-8


### PR DESCRIPTION
現在のリファレンスマニュアルは余計な「+」が入るなど正しくHTML化されていない箇所が多数あります。

* 例: https://test-unit.github.io/test-unit/ja/Test/Unit/Assertions.html#assert_in_epsilon-instance_method
![image](https://user-images.githubusercontent.com/830872/58314286-28e09f80-7e4a-11e9-8cd5-0772b22827e3.png)

これは、ソースコードのコメントがRDoc形式で書かれているのにYARDがMarkdown形式として処理しているのが原因だと思います。

`.yardopts` の `--markup` オプションの指定を `markdown` から `rdoc` へ変更することで正しくHTML化されるようなので、そのような変更を作成しました。これにより上の例は次のような見栄えに変わります。

* 変更後の見栄え
![image](https://user-images.githubusercontent.com/830872/58312409-2f6d1800-7e46-11e9-8f95-0df230059d4c.png)

`--markup` で　`markdown` が指定されていたのはREADMEなどがMarkdown形式で書かれているからなのかな思いましたが、拡張子が `.md` のファイルは `--markup` の指定に依らずにmarkdownとして処理されるようなので、ここは `rdoc` を指定すべきではないでしょうか。
