### PR TITLE
Convert markup format of source codes from RDoc to Markdown

### DIFF
--- a/doc/po/ja.po
+++ b/doc/po/ja.po
@@ -844,11 +844,10 @@ msgstr ""
 msgid "## 3.2.8 - 2018-05-13 {#version-3-2-8}"
 msgstr ""
 
-#, fuzzy
 msgid ""
 "  * [UI][console]: Changed to put code snippet before backtrace on\n"
 "    reverse mode."
-msgstr "修正前"
+msgstr ""
 
 msgid "## 3.2.7 - 2017-12-12 {#version-3-2-7}"
 msgstr ""
@@ -3280,13 +3279,12 @@ msgstr ""
 msgid "3.0.0"
 msgstr ""
 
-#, fuzzy
 msgid ""
 "Passes if `object`.instance_of?(`klass`) does not hold.\n"
 "When `klass` is an array of classes, it passes if no class\n"
 "satisfies +object.instance_of?(class).\n"
 "Just for minitest compatibility. :<"
-msgstr "minitestとの互換製のためだけのリリースです。 :"
+msgstr ""
 
 # Test::Unit::Assertions#assert_nil
 msgid "Passes if `object` is nil."
@@ -3324,13 +3322,12 @@ msgid ""
 "assert_not_kind_of([Fixnum, NilClass], 100) # -> fail"
 msgstr ""
 
-#, fuzzy
 msgid ""
 "Passes if `object`.kind_of?(`klass`) does not hold.\n"
 "When `klass` is an array of classes or modules, it passes only if all\n"
 "classes (and modules) do not satisfy +object.kind_of?(class_or_module).\n"
 "Just for minitest compatibility. :<"
-msgstr "minitestとの互換製のためだけのリリースです。 :"
+msgstr ""
 
 # Test::Unit::Assertions#assert_respond_to
 msgid "Passes if `object` .respond_to? `method`"
@@ -3350,11 +3347,10 @@ msgid ""
 "assert_not_respond_to('bugbear', :size)         # -> fail"
 msgstr ""
 
-#, fuzzy
 msgid ""
 "Passes if `object` does not .respond_to? `method`.\n"
 "Just for minitest compatibility. :<"
-msgstr "minitestとの互換製のためだけのリリースです。 :"
+msgstr ""
 
 # Test::Unit::Assertions#assert_match
 msgid "Passes if `pattern` =~ `string`."
@@ -3433,11 +3429,10 @@ msgstr ""
 msgid "assert_not_same Object.new, Object.new"
 msgstr ""
 
-#, fuzzy
 msgid ""
 "Passes if ! `actual` .equal? `expected`\n"
 "Just for minitest compatibility. :<"
-msgstr "minitestとの互換製のためだけのリリースです。 :"
+msgstr ""
 
 # Test::Unit::Assertions#assert_not_equal
 msgid "Passes if `expected` != `actual`"
@@ -3447,11 +3442,10 @@ msgstr ""
 msgid "assert_not_equal 'some string', 5"
 msgstr ""
 
-#, fuzzy
 msgid ""
 "Passes if `expected` != `actual`\n"
 "Just for minitest compatibility. :<"
-msgstr "minitestとの互換製のためだけのリリースです。 :"
+msgstr ""
 
 # Test::Unit::Assertions#assert_not_nil
 msgid "Passes if ! `object` .nil?"
@@ -3461,11 +3455,10 @@ msgstr ""
 msgid "assert_not_nil '1 two 3'.sub!(/two/, '2')"
 msgstr ""
 
-#, fuzzy
 msgid ""
 "Passes if ! `object` .nil?\n"
 "Just for minitest compatibility. :<"
-msgstr "minitestとの互換製のためだけのリリースです。 :"
+msgstr ""
 
 # Test::Unit::Assertions#assert_no_match
 # Test::Unit::Assertions#assert_not_match
@@ -3478,11 +3471,10 @@ msgid ""
 "assert_not_match(/three/, 'one 2 three') # -> fail"
 msgstr ""
 
-#, fuzzy
 msgid ""
 "Passes if `regexp` !~ `string`\n"
 "Just for minitest compatibility. :<"
-msgstr "minitestとの互換製のためだけのリリースです。 :"
+msgstr ""
 
 # Test::Unit::Assertions#assert_no_match
 msgid "Deprecated. Use #assert_not_match instead."
@@ -3509,11 +3501,10 @@ msgid ""
 "end"
 msgstr ""
 
-#, fuzzy
 msgid ""
 "Passes if the block throws `expected_object`\n"
 "Just for minitest compatibility. :<"
-msgstr "minitestとの互換製のためだけのリリースです。 :"
+msgstr ""
 
 # Test::Unit::Assertions#assert_nothing_thrown
 msgid "Passes if block does not throw anything."
@@ -3548,12 +3539,11 @@ msgid ""
 "assert_not_in_delta(0.05, (50000.0 / 10**6), 0.00001) # -> fail"
 msgstr ""
 
-#, fuzzy
 msgid ""
 "Passes if `expected_float` and `actual_float` are\n"
 "not equal within `delta` tolerance.\n"
 "Just for minitest compatibility. :<"
-msgstr "minitestとの互換製のためだけのリリースです。 :"
+msgstr ""
 
 # Test::Unit::Assertions#assert_in_epsilon
 msgid ""
@@ -3580,13 +3570,12 @@ msgid ""
 "assert_not_in_epsilon(10000.0, 9899.0, 0.1) # -> pass"
 msgstr ""
 
-#, fuzzy
 msgid ""
 "Passes if `expected_float` and `actual_float` are\n"
 "not equal within `epsilon` relative error of\n"
 "`expected_float`.\n"
 "Just for minitest compatibility. :<"
-msgstr "minitestとの互換製のためだけのリリースです。 :"
+msgstr ""
 
 # Test::Unit::Assertions#assert_send
 msgid "Passes if the method send returns a true value."
@@ -3721,11 +3710,10 @@ msgid ""
 "assert_not_predicate([], :empty?)  # -> fail"
 msgstr ""
 
-#, fuzzy
 msgid ""
 "Passes if `object`.`predicate` is not _true_.\n"
 "Just for minitest compatibility. :<"
-msgstr "minitestとの互換製のためだけのリリースです。 :"
+msgstr ""
 
 # Test::Unit::Assertions#assert_alias_method
 msgid ""
@@ -3774,11 +3762,10 @@ msgid ""
 "assert_include(1..10, 20)             # -> fail"
 msgstr ""
 
-#, fuzzy
 msgid ""
 "Passes if `collection` includes `object`.\n"
 "Just for minitest compatibility. :<"
-msgstr "minitestとの互換製のためだけのリリースです。 :"
+msgstr ""
 
 # Test::Unit::Assertions#assert_not_include
 msgid "Passes if `collection` doesn't include `object`."
@@ -3792,11 +3779,10 @@ msgid ""
 "assert_not_include(1..10, 5)              # -> fail"
 msgstr ""
 
-#, fuzzy
 msgid ""
 "Passes if `collection` doesn't include `object`.\n"
 "Just for minitest compatibility. :<"
-msgstr "minitestとの互換製のためだけのリリースです。 :"
+msgstr ""
 
 # Test::Unit::Assertions#assert_empty
 msgid "Passes if `object` is empty."
@@ -3826,18 +3812,16 @@ msgid ""
 "assert_not_empty({})                       # -> fail"
 msgstr ""
 
-#, fuzzy
 msgid ""
 "Passes if `object` is not empty.\n"
 "Just for minitest compatibility. :<"
-msgstr "minitestとの互換製のためだけのリリースです。 :"
+msgstr ""
 
-#, fuzzy
 msgid ""
 "Builds a failure message.  `user_message` is added before the\n"
 "`template` and `arguments` replaces the '?'s positionally in\n"
 "the template."
-msgstr "修正前"
+msgstr ""
 
 # Test::Unit::Assertions#add_assertion
 msgid ""
@@ -4390,9 +4374,8 @@ msgid ""
 "File format is automatically detected from filename extension."
 msgstr "データファイルのフルパスを指定します。ファイルフォーマットはファイルの拡張子から自動的に判別します。"
 
-#, fuzzy
 msgid "if `file_name` is not supported file format."
-msgstr "+file_name+ がサポートされていないファイルフォーマットのときに発生します。"
+msgstr "`file_name` がサポートされていないファイルフォーマットのときに発生します。"
 
 # @see
 msgid "tag|see|Loader#load"

--- a/doc/po/ja.po
+++ b/doc/po/ja.po
@@ -18,9 +18,9 @@ msgid "# test-unit"
 msgstr ""
 
 msgid ""
-"[![](https://badge.fury.io/rb/test-unit.png)](http://badge.fury.io/rb/test-uni"
+"[![](https://badge.fury.io/rb/test-unit.svg)](http://badge.fury.io/rb/test-uni"
 "t)\n"
-"[![](https://travis-ci.org/test-unit/test-unit.png?branch=master)](https://tra"
+"[![](https://travis-ci.org/test-unit/test-unit.svg?branch=master)](https://tra"
 "vis-ci.org/test-unit/test-unit)"
 msgstr ""
 
@@ -670,11 +670,243 @@ msgstr ""
 msgid "# News"
 msgstr ""
 
-msgid "## 3.2.4 - 2017-05-23 {#version-3-2-4}"
+msgid "## 3.3.3 - 2019-05-10 {#version-3-3-3}"
+msgstr ""
+
+#, fuzzy
+msgid "### Fixed"
+msgstr "### 修正"
+
+msgid ""
+"  * Fixed a bug that priority mode with test case name that uses\n"
+"    special characters such as `?` can't be used on Windows."
+msgstr ""
+
+msgid "## 3.3.2 - 2019-04-11 {#version-3-3-2}"
+msgstr ""
+
+msgid "### Fixes"
+msgstr "### 修正"
+
+msgid ""
+"  * Fixed a bug that `Test::Unit::Collector::Load` doesn't load test\n"
+"    files under sub directories when these files have the same base\n"
+"    name as test files in upper directories.\n"
+"    [Reported by Kenta Murata]"
+msgstr ""
+
+msgid "### Thanks"
+msgstr "### 感謝"
+
+msgid "  * Kenta Murata"
+msgstr ""
+
+msgid "## 3.3.1 - 2019-03-27 {#version-3-3-1}"
 msgstr ""
 
 msgid "### Improvements"
 msgstr "### 改良"
+
+msgid ""
+"  * Added support for `Test::Unit::AssertionFailedError#user_message`\n"
+"    for not only `assert_equal` and `assert_raise` but also all\n"
+"    assertions.\n"
+"    [GitHub#162][Reported by xgraffm]"
+msgstr ""
+
+msgid "  * xgraffm"
+msgstr ""
+
+msgid "## 3.3.0 - 2019-01-23 {#version-3-3-0}"
+msgstr ""
+
+msgid ""
+"  * Added support for auto test run when all tests are defined in\n"
+"    modules."
+msgstr ""
+
+msgid ""
+"  * Added support for defining methods to test case class in multiple\n"
+"    threads.\n"
+"    [GitHub#159][Reported by Charles Oliver Nutter]"
+msgstr ""
+
+msgid ""
+"  * Suppressed warnings on Ruby 2.5.\n"
+"    [GitHub#160][Reported by Daniel Berger]"
+msgstr ""
+
+msgid "  * Suppressed warnings on Ruby 2.7."
+msgstr ""
+
+msgid ""
+"  * Fixed a code snippet fetch failure when source code isn't UTF-8\n"
+"    and the default external encoding is set to not UTF-8.\n"
+"    [GitHub#161][Reported by masa kunikata]"
+msgstr ""
+
+msgid "  * Charles Oliver Nutter"
+msgstr ""
+
+msgid "  * Daniel Berger"
+msgstr ""
+
+msgid "  * masa kunikata"
+msgstr ""
+
+msgid "## 3.2.9 - 2018-12-01 {#version-3-2-9}"
+msgstr ""
+
+msgid ""
+"  * Added support for data generation by method. `data_#{test_name}`\n"
+"    is called to generate data for `test_name` test."
+msgstr ""
+
+msgid "  * Added support for data matrix generation."
+msgstr ""
+
+msgid "    Example:"
+msgstr ""
+
+msgid ""
+"    ```ruby\n"
+"    data(:a, [0, 1, 2])\n"
+"    data(:b, [:x, :y])\n"
+"    def test_data(data)\n"
+"    end\n"
+"    ```"
+msgstr ""
+
+msgid "    This example generates the following data matrix:"
+msgstr ""
+
+msgid ""
+"      * label: `\"a: 0, b: :x\"`, data: `{a: 0, b: :x}`\n"
+"      * label: `\"a: 0, b: :y\"`, data: `{a: 0, b: :y}`\n"
+"      * label: `\"a: 1, b: :x\"`, data: `{a: 1, b: :x}`\n"
+"      * label: `\"a: 1, b: :y\"`, data: `{a: 1, b: :y}`\n"
+"      * label: `\"a: 2, b: :x\"`, data: `{a: 2, b: :x}`\n"
+"      * label: `\"a: 2, b: :y\"`, data: `{a: 2, b: :y}`"
+msgstr ""
+
+msgid "  * Added `Test::Unit::TestCase#data` that returns the current data."
+msgstr ""
+
+msgid ""
+"  * Added support for using test method that doesn't have no\n"
+"    parameters as data driven test."
+msgstr ""
+
+msgid ""
+"    ```ruby\n"
+"    data(\"label\", :value)\n"
+"    def test_data # Available since this release\n"
+"      p data # :value\n"
+"    end\n"
+"    ```"
+msgstr ""
+
+msgid "  * Added support for `:keep` option to `Test::Unit::TestCase.data`."
+msgstr ""
+
+msgid ""
+"  * Added support for `:group` option to\n"
+"    `Test::Unit::TestCase.data`. It's useful to generate multiple data\n"
+"    matrix groups."
+msgstr ""
+
+msgid ""
+"    ```ruby\n"
+"    # Group1\n"
+"    data(:a, [0, 1, 2], group: :g1)\n"
+"    data(:b, [:x, :y], group: :g1)\n"
+"    # Group2\n"
+"    data(:a, [:x, :y], group: :g2)\n"
+"    data(:c, [-1, -2], group: :g2)\n"
+"    def test_data(data)\n"
+"    end\n"
+"    ```"
+msgstr ""
+
+msgid ""
+"      * label: `\"group: :g1, a: 0, b: :x\"`, data: `{a: 0, b: :x}`\n"
+"      * label: `\"group: :g1, a: 0, b: :y\"`, data: `{a: 0, b: :y}`\n"
+"      * label: `\"group: :g1, a: 1, b: :x\"`, data: `{a: 1, b: :x}`\n"
+"      * label: `\"group: :g1, a: 1, b: :y\"`, data: `{a: 1, b: :y}`\n"
+"      * label: `\"group: :g1, a: 2, b: :x\"`, data: `{a: 2, b: :x}`\n"
+"      * label: `\"group: :g1, a: 2, b: :y\"`, data: `{a: 2, b: :y}`\n"
+"      * label: `\"group: :g2, a: :x, b: -1\"`, data: `{a: :x, b: -1}`\n"
+"      * label: `\"group: :g2, a: :x, b: -2\"`, data: `{a: :x, b: -2}`\n"
+"      * label: `\"group: :g2, a: :y, b: -1\"`, data: `{a: :y, b: -1}`\n"
+"      * label: `\"group: :g2, a: :y, b: -2\"`, data: `{a: :y, b: -2}`"
+msgstr ""
+
+msgid "## 3.2.8 - 2018-05-13 {#version-3-2-8}"
+msgstr ""
+
+#, fuzzy
+msgid ""
+"  * [UI][console]: Changed to put code snippet before backtrace on\n"
+"    reverse mode."
+msgstr "修正前"
+
+msgid "## 3.2.7 - 2017-12-12 {#version-3-2-7}"
+msgstr ""
+
+msgid ""
+"  * Added source code link to gemspec.\n"
+"    [GitHub#157][Patch by Grey Baker]"
+msgstr ""
+
+msgid ""
+"  * Changed to use SVG image for badges in README.\n"
+"    [GitHub#158][Patch by Olle Jonsson]"
+msgstr ""
+
+msgid ""
+"  * [UI][console]: Added `--reverse-output` option to output fault\n"
+"    details in reverse like Ruby 2.5. It's enabled by default only for\n"
+"    tty output."
+msgstr ""
+
+msgid ""
+"  * Fixed a typo.\n"
+"    [GitHub#156][Patch by masa kunikata]"
+msgstr ""
+
+msgid "  * [UI][console]: Fixed a bug that broken align in verbose mode."
+msgstr ""
+
+msgid "  * Grey Baker"
+msgstr ""
+
+msgid "  * Olle Jonsson"
+msgstr ""
+
+msgid "## 3.2.6 - 2017-09-21 {#version-3-2-6}"
+msgstr ""
+
+msgid ""
+"  * Changed test file require failure to error from omission.\n"
+"    [GitHub#154][Patch by naofumi-fujii]"
+msgstr ""
+
+msgid "  * naofumi-fujii"
+msgstr ""
+
+msgid "## 3.2.5 - 2017-06-24 {#version-3-2-5}"
+msgstr ""
+
+msgid ""
+"  * Supported `--enable-frozen-string-literal` `ruby` option.\n"
+"    [GitHub#149][Reported by Pat Allan]"
+msgstr ""
+
+msgid "  * Pat Allan"
+msgstr ""
+
+msgid "## 3.2.4 - 2017-05-23 {#version-3-2-4}"
+msgstr ""
 
 msgid "  * Updated tests for Ruby 2.4. [GitHUb#136][Patch by Kazuki Tsujimoto]"
 msgstr ""
@@ -697,9 +929,6 @@ msgstr ""
 
 msgid "  * Updated `.travis.yml`. [GitHub#145][Patch by Jun Aruga]"
 msgstr ""
-
-msgid "### Fixes"
-msgstr "### 修正"
 
 msgid "  * Fixed a contributor name. [GitHub#131][Patch by Akira Matsuda]"
 msgstr ""
@@ -732,9 +961,6 @@ msgid ""
 "  * Fixed a bug that `--no-show-detail-immediately` raises an error.\n"
 "    [GitHub#147][Reported by MSP-Greg]"
 msgstr ""
-
-msgid "### Thanks"
-msgstr "### 感謝"
 
 msgid "  * Akira Matsuda"
 msgstr ""
@@ -1181,9 +1407,6 @@ msgid ""
 "  * Stopped to remove JRuby and Rubinius internal backtrace entries from\n"
 "    backtrace on failure/error.\n"
 "    [GitHub#82][Patch by Charles Oliver Nutter]"
-msgstr ""
-
-msgid "  * Charles Oliver Nutter"
 msgstr ""
 
 msgid "## 3.0.3 - 2014-10-29 {#version-3-0-3}"
@@ -2112,29 +2335,15 @@ msgstr ""
 msgid "  * Birthday (as a gem)!"
 msgstr ""
 
-# Test
-msgid "port of Python's difflib."
-msgstr ""
-
-# Test
-msgid ""
-"Copyright (c) 2001-2008 Python Software Foundation; All Rights Reserved\n"
-"Copyright (c) 2008-2011 Kouhei Sutou; All Rights Reserved"
+msgid ":nodoc:"
 msgstr ""
 
 # Test::Unit
-msgid "= Test::Unit - Ruby Unit Testing Framework"
-msgstr ""
-
-# Test
-msgid ""
-"It is free software, and is distributed under the Ruby license, the\n"
-"PSF license and/or LGPLv2.1 or later. See the COPYING file, the PSFL\n"
-"file and the LGPL file."
+msgid "# Test::Unit - Ruby Unit Testing Framework"
 msgstr ""
 
 # Test::Unit
-msgid "== Introduction"
+msgid "## Introduction"
 msgstr ""
 
 # Test::Unit
@@ -2160,13 +2369,7 @@ msgid ""
 msgstr ""
 
 # Test::Unit
-msgid "== Notes"
-msgstr ""
-
-# #run
-msgid ""
-"experimental. It is for \"ruby -rtest-unit -e run test/test_*.rb\".\n"
-"Is this API OK or dirty?"
+msgid "## Notes"
 msgstr ""
 
 msgid "Test::Unit has grown out of and superceded Lapidary."
@@ -2179,7 +2382,7 @@ msgid ""
 msgstr ""
 
 # Test::Unit
-msgid "== Feedback"
+msgid "## Feedback"
 msgstr ""
 
 # Test::Unit
@@ -2197,7 +2400,7 @@ msgid ""
 msgstr ""
 
 # Test::Unit
-msgid "== Contact Information"
+msgid "## Contact Information"
 msgstr ""
 
 # Test::Unit
@@ -2211,7 +2414,7 @@ msgid ""
 msgstr ""
 
 # Test::Unit
-msgid "== Credits"
+msgid "## Credits"
 msgstr ""
 
 msgid "I'd like to thank..."
@@ -2263,10 +2466,6 @@ msgid "My Creator, for giving me life, and giving it more abundantly."
 msgstr ""
 
 # Test::Unit
-msgid "== License"
-msgstr ""
-
-# Test::Unit
 msgid ""
 "Test::Unit is copyright (c) 2000-2003 Nathaniel Talbott. It is free\n"
 "software, and is distributed under the Ruby license. See the COPYING\n"
@@ -2283,7 +2482,7 @@ msgid ""
 msgstr ""
 
 # Test::Unit
-msgid "== Warranty"
+msgid "## Warranty"
 msgstr ""
 
 # Test::Unit
@@ -2295,7 +2494,7 @@ msgid ""
 msgstr ""
 
 # Test::Unit
-msgid "== Author"
+msgid "## Author"
 msgstr ""
 
 # Test::Unit
@@ -2309,7 +2508,7 @@ msgid "----"
 msgstr ""
 
 # Test::Unit
-msgid "= Usage"
+msgid "# Usage"
 msgstr ""
 
 # Test::Unit
@@ -2325,7 +2524,7 @@ msgid ""
 msgstr ""
 
 # Test::Unit
-msgid "== Assertions"
+msgid "## Assertions"
 msgstr ""
 
 # Test::Unit
@@ -2341,7 +2540,7 @@ msgid ""
 msgstr ""
 
 # Test::Unit
-msgid "== Test Method & Test Fixture"
+msgid "## Test Method & Test Fixture"
 msgstr ""
 
 # Test::Unit
@@ -2424,7 +2623,7 @@ msgid ""
 msgstr ""
 
 # Test::Unit
-msgid "== Test Runners"
+msgid "## Test Runners"
 msgstr ""
 
 # Test::Unit
@@ -2441,12 +2640,12 @@ msgstr ""
 
 # Test::Unit
 msgid ""
-"   require 'test/unit'\n"
-"   Test::Unit::AutoRunner.default_runner = \"gtk2\""
+"    require 'test/unit'\n"
+"    Test::Unit::AutoRunner.default_runner = \"gtk2\""
 msgstr ""
 
 # Test::Unit
-msgid "== Test Suite"
+msgid "## Test Suite"
 msgstr ""
 
 # Test::Unit
@@ -2472,10 +2671,10 @@ msgstr ""
 
 # Test::Unit
 msgid ""
-" require 'test/unit'\n"
-" require 'test_myfirsttests'\n"
-" require 'test_moretestsbyme'\n"
-" require 'test_anothersetoftests'"
+"    require 'test/unit'\n"
+"    require 'test_myfirsttests'\n"
+"    require 'test_moretestsbyme'\n"
+"    require 'test_anothersetoftests'"
 msgstr ""
 
 # Test::Unit
@@ -2486,7 +2685,7 @@ msgid ""
 msgstr ""
 
 # Test::Unit
-msgid "== Configuration file"
+msgid "## Configuration file"
 msgstr ""
 
 msgid ""
@@ -2504,40 +2703,26 @@ msgstr "カラースキーム定義以外はコマンドラインオプション
 
 # Test::Unit
 msgid ""
-"  color_schemes:\n"
-"    inverted:\n"
-"      success:\n"
-"        name: red\n"
-"        bold: true\n"
-"      failure:\n"
-"        name: green\n"
-"        bold: true\n"
-"    other_scheme:\n"
-"      ..."
+"SCHEME_NAME\n"
+": the name of the color scheme"
 msgstr ""
 
 # Test::Unit
 msgid ""
-" color_schemes:\n"
-"   SCHEME_NAME:\n"
-"     EVENT_NAME:\n"
-"       name: COLOR_NAME\n"
-"       intensity: BOOLEAN\n"
-"       bold: BOOLEAN\n"
-"       italic: BOOLEAN\n"
-"       underline: BOOLEAN\n"
-"     ...\n"
-"   ..."
+"EVENT_NAME\n"
+": one of [success, failure, pending, omission, notification, error]"
 msgstr ""
 
 # Test::Unit
 msgid ""
-"SCHEME_NAME:: the name of the color scheme\n"
-"EVENT_NAME:: one of [success, failure, pending,\n"
-"             omission, notification, error]\n"
-"COLOR_NAME:: one of [black, red, green, yellow, blue,\n"
-"             magenta, cyan, white]\n"
-"BOOLEAN:: true or false"
+"COLOR_NAME\n"
+": one of [black, red, green, yellow, blue, magenta, cyan, white]"
+msgstr ""
+
+# Test::Unit
+msgid ""
+"BOOLEAN\n"
+": true or false"
 msgstr ""
 
 msgid ""
@@ -2546,22 +2731,7 @@ msgid ""
 msgstr "上で定義した'inverted'カラースキムを使う設定は以下の通りです。"
 
 # Test::Unit
-msgid ""
-"  runner: console\n"
-"  console_options:\n"
-"    color_scheme: inverted\n"
-"  color_schemes:\n"
-"    inverted:\n"
-"      success:\n"
-"        name: red\n"
-"        bold: true\n"
-"      failure:\n"
-"        name: green\n"
-"        bold: true"
-msgstr ""
-
-# Test::Unit
-msgid "== Questions?"
+msgid "## Questions?"
 msgstr ""
 
 # Test::Unit
@@ -2571,6 +2741,10 @@ msgid ""
 "missing points, etc., in this document (or any other)."
 msgstr ""
 
+# @deprecated
+msgid "Use Test::Unit::AutoRunner.need_auto_run= instead."
+msgstr ""
+
 # Test::Unit.run=
 msgid ""
 "Set true when Test::Unit has run.  If set to true Test::Unit\n"
@@ -2578,15 +2752,11 @@ msgid ""
 msgstr ""
 
 # @deprecated
-msgid "Use Test::Unit::AutoRunner.need_auto_run= instead."
+msgid "Use Test::Unit::AutoRunner.need_auto_run? instead."
 msgstr ""
 
 # Test::Unit.run?
 msgid "Already tests have run?"
-msgstr ""
-
-# @deprecated
-msgid "Use Test::Unit::AutoRunner.need_auto_run? instead."
 msgstr ""
 
 msgid "private"
@@ -2598,19 +2768,49 @@ msgid ""
 "To register multiple hooks, call this method multiple times."
 msgstr ""
 
+# Test::Unit.at_exit
 # Test::Unit.at_start
-msgid ""
-"Here is an example test case:\n"
-"  Test::Unit.at_start do\n"
-"    # ...\n"
-"  end"
+# Test::Unit::TestCase.shutdown
+# Test::Unit::TestCase.startup
+msgid "Here is an example test case:"
 msgstr ""
 
 # Test::Unit.at_start
 msgid ""
-"  class TestMyClass1 < Test::Unit::TestCase\n"
-"    class << self\n"
-"      def startup\n"
+"    Test::Unit.at_start do\n"
+"      # ...\n"
+"    end"
+msgstr ""
+
+# Test::Unit.at_start
+msgid ""
+"    class TestMyClass1 < Test::Unit::TestCase\n"
+"      class << self\n"
+"        def startup\n"
+"          # ...\n"
+"        end\n"
+"      end"
+msgstr ""
+
+# Test::Unit.at_start
+msgid ""
+"      def setup\n"
+"        # ...\n"
+"      end"
+msgstr ""
+
+# Test::Unit.at_exit
+# Test::Unit.at_start
+msgid ""
+"      def test_my_class1\n"
+"        # ...\n"
+"      end"
+msgstr ""
+
+# Test::Unit.at_exit
+# Test::Unit.at_start
+msgid ""
+"      def test_my_class2\n"
 "        # ...\n"
 "      end\n"
 "    end"
@@ -2618,41 +2818,20 @@ msgstr ""
 
 # Test::Unit.at_start
 msgid ""
-"    def setup\n"
-"      # ...\n"
-"    end"
+"    class TestMyClass2 < Test::Unit::TestCase\n"
+"      class << self\n"
+"        def startup\n"
+"          # ...\n"
+"        end\n"
+"      end"
 msgstr ""
 
-# Test::Unit.at_exit
-# Test::Unit.at_start
-msgid ""
-"    def test_my_class1\n"
-"      # ...\n"
-"    end"
-msgstr ""
-
-# Test::Unit.at_exit
-# Test::Unit.at_start
-msgid ""
-"    def test_my_class2\n"
-"      # ...\n"
-"    end\n"
-"  end"
+# Test::Unit::TestCase
+msgid "Here is a call order:"
 msgstr ""
 
 # Test::Unit.at_start
 msgid ""
-"  class TestMyClass2 < Test::Unit::TestCase\n"
-"    class << self\n"
-"      def startup\n"
-"        # ...\n"
-"      end\n"
-"    end"
-msgstr ""
-
-# Test::Unit.at_start
-msgid ""
-"Here is a call order:\n"
 "* at_start\n"
 "* TestMyClass1.startup\n"
 "* TestMyClass1#setup\n"
@@ -2672,12 +2851,12 @@ msgid ""
 "end"
 msgstr ""
 
-# @yield
-msgid "A block that is run before running tests."
-msgstr ""
-
 # @since
 msgid "2.5.2"
+msgstr ""
+
+# @yield
+msgid "A block that is run before running tests."
 msgstr ""
 
 # Test::Unit.at_exit
@@ -2688,42 +2867,40 @@ msgstr ""
 
 # Test::Unit.at_exit
 msgid ""
-"Here is an example test case:\n"
-"  Test::Unit.at_exit do\n"
-"    # ...\n"
-"  end"
-msgstr ""
-
-# Test::Unit.at_exit
-msgid ""
-"  class TestMyClass1 < Test::Unit::TestCase\n"
-"    class << self\n"
-"      def shutdown\n"
-"        # ...\n"
-"      end\n"
-"    end"
-msgstr ""
-
-# Test::Unit.at_exit
-msgid ""
-"    def teardown\n"
+"    Test::Unit.at_exit do\n"
 "      # ...\n"
 "    end"
 msgstr ""
 
 # Test::Unit.at_exit
 msgid ""
-"  class TestMyClass2 < Test::Unit::TestCase\n"
-"    class << self\n"
-"      def shutdown\n"
-"        # ...\n"
-"      end\n"
-"    end"
+"    class TestMyClass1 < Test::Unit::TestCase\n"
+"      class << self\n"
+"        def shutdown\n"
+"          # ...\n"
+"        end\n"
+"      end"
 msgstr ""
 
 # Test::Unit.at_exit
 msgid ""
-"Here is a call order:\n"
+"      def teardown\n"
+"        # ...\n"
+"      end"
+msgstr ""
+
+# Test::Unit.at_exit
+msgid ""
+"    class TestMyClass2 < Test::Unit::TestCase\n"
+"      class << self\n"
+"        def shutdown\n"
+"          # ...\n"
+"        end\n"
+"      end"
+msgstr ""
+
+# Test::Unit.at_exit
+msgid ""
 "* TestMyClass1#test_my_class1\n"
 "* TestMyClass1#teardown\n"
 "* TestMyClass1#test_my_class2\n"
@@ -2845,9 +3022,9 @@ msgstr ""
 # @example Example Custom Assertion
 msgid ""
 "\n"
-"def deny(boolean, message = nil)\n"
-"  message = build_message message, '<?> is not false or nil.', boolean\n"
-"  assert_block message do\n"
+"def deny(boolean, message=nil)\n"
+"  message = build_message(message, '<?> is not false or nil.', boolean)\n"
+"  assert_block(message) do\n"
 "    not boolean\n"
 "  end\n"
 "end"
@@ -2987,14 +3164,7 @@ msgid ""
 msgstr ""
 
 # Test::Unit::Assertions#refute
-msgid "Asserts that +object+ is false or nil."
-msgstr ""
-
-msgid "Just for minitest compatibility. :<"
-msgstr "minitestとの互換製のためだけのリリースです。 :"
-
-# @param [Object] object
-msgid "The object to be asserted."
+msgid "Asserts that `object` is false or nil."
 msgstr ""
 
 # @example Pass patterns
@@ -3009,12 +3179,19 @@ msgid ""
 "refute(\"string\") # => failure"
 msgstr ""
 
+msgid "Just for minitest compatibility. :<"
+msgstr "minitestとの互換製のためだけのリリースです。 :"
+
+# @param [Object] object
+msgid "The object to be asserted."
+msgstr ""
+
 # @since
 msgid "2.5.3"
 msgstr ""
 
 # Test::Unit::Assertions#assert_equal
-msgid "Passes if +expected+ == +actual+."
+msgid "Passes if `expected` == `actual`."
 msgstr ""
 
 # Test::Unit::Assertions#assert_equal
@@ -3073,7 +3250,7 @@ msgstr ""
 
 # Test::Unit::Assertions#assert_instance_of
 msgid ""
-"Passes if +object+.instance_of?(+klass+). When +klass+ is\n"
+"Passes if `object`.instance_of?(`klass`). When `klass` is\n"
 "an array of classes, it passes if any class\n"
 "satisfies +object.instance_of?(class)."
 msgstr ""
@@ -3086,10 +3263,9 @@ msgid ""
 msgstr ""
 
 # Test::Unit::Assertions#assert_not_instance_of
-# Test::Unit::Assertions#refute_instance_of
 msgid ""
-"Passes if +object+.instance_of?(+klass+) does not hold.\n"
-"When +klass+ is an array of classes, it passes if no class\n"
+"Passes if `object`.instance_of?(`klass`) does not hold.\n"
+"When `klass` is an array of classes, it passes if no class\n"
 "satisfies +object.instance_of?(class)."
 msgstr ""
 
@@ -3104,15 +3280,16 @@ msgstr ""
 msgid "3.0.0"
 msgstr ""
 
+#, fuzzy
 msgid ""
-"Passes if +object+.instance_of?(+klass+) does not hold.\n"
-"When +klass+ is an array of classes, it passes if no class\n"
+"Passes if `object`.instance_of?(`klass`) does not hold.\n"
+"When `klass` is an array of classes, it passes if no class\n"
 "satisfies +object.instance_of?(class).\n"
 "Just for minitest compatibility. :<"
-msgstr ""
+msgstr "minitestとの互換製のためだけのリリースです。 :"
 
 # Test::Unit::Assertions#assert_nil
-msgid "Passes if +object+ is nil."
+msgid "Passes if `object` is nil."
 msgstr ""
 
 # @example
@@ -3121,7 +3298,7 @@ msgstr ""
 
 # Test::Unit::Assertions#assert_kind_of
 msgid ""
-"Passes if +object+.kind_of?(+klass+). When +klass+ is\n"
+"Passes if `object`.kind_of?(`klass`). When `klass` is\n"
 "an array of classes or modules, it passes if any\n"
 "class or module satisfies +object.kind_of?(class_or_module)."
 msgstr ""
@@ -3134,10 +3311,9 @@ msgid ""
 msgstr ""
 
 # Test::Unit::Assertions#assert_not_kind_of
-# Test::Unit::Assertions#refute_kind_of
 msgid ""
-"Passes if +object+.kind_of?(+klass+) does not hold.\n"
-"When +klass+ is an array of classes or modules, it passes only if all\n"
+"Passes if `object`.kind_of?(`klass`) does not hold.\n"
+"When `klass` is an array of classes or modules, it passes only if all\n"
 "classes (and modules) do not satisfy +object.kind_of?(class_or_module)."
 msgstr ""
 
@@ -3148,15 +3324,16 @@ msgid ""
 "assert_not_kind_of([Fixnum, NilClass], 100) # -> fail"
 msgstr ""
 
+#, fuzzy
 msgid ""
-"Passes if +object+.kind_of?(+klass+) does not hold.\n"
-"When +klass+ is an array of classes or modules, it passes only if all\n"
+"Passes if `object`.kind_of?(`klass`) does not hold.\n"
+"When `klass` is an array of classes or modules, it passes only if all\n"
 "classes (and modules) do not satisfy +object.kind_of?(class_or_module).\n"
 "Just for minitest compatibility. :<"
-msgstr ""
+msgstr "minitestとの互換製のためだけのリリースです。 :"
 
 # Test::Unit::Assertions#assert_respond_to
-msgid "Passes if +object+ .respond_to? +method+"
+msgid "Passes if `object` .respond_to? `method`"
 msgstr ""
 
 # @example
@@ -3164,8 +3341,7 @@ msgid "assert_respond_to 'bugbear', :slice"
 msgstr ""
 
 # Test::Unit::Assertions#assert_not_respond_to
-# Test::Unit::Assertions#refute_respond_to
-msgid "Passes if +object+ does not .respond_to? +method+."
+msgid "Passes if `object` does not .respond_to? `method`."
 msgstr ""
 
 # @example
@@ -3174,13 +3350,14 @@ msgid ""
 "assert_not_respond_to('bugbear', :size)         # -> fail"
 msgstr ""
 
+#, fuzzy
 msgid ""
-"Passes if +object+ does not .respond_to? +method+.\n"
+"Passes if `object` does not .respond_to? `method`.\n"
 "Just for minitest compatibility. :<"
-msgstr ""
+msgstr "minitestとの互換製のためだけのリリースです。 :"
 
 # Test::Unit::Assertions#assert_match
-msgid "Passes if +pattern+ =~ +string+."
+msgid "Passes if `pattern` =~ `string`."
 msgstr ""
 
 # @example
@@ -3189,7 +3366,7 @@ msgstr ""
 
 # Test::Unit::Assertions#assert_same
 msgid ""
-"Passes if +actual+ .equal? +expected+ (i.e. they are the same\n"
+"Passes if `actual` .equal? `expected` (i.e. they are the same\n"
 "instance)."
 msgstr ""
 
@@ -3202,7 +3379,7 @@ msgstr ""
 # Test::Unit::Assertions#assert_not_operator
 # Test::Unit::Assertions#assert_operator
 # Test::Unit::Assertions#refute_operator
-msgid "Compares the +object1+ with +object2+ using +operator+."
+msgid "Compares the `object1` with `object2` using `operator`."
 msgstr ""
 
 # Test::Unit::Assertions#assert_operator
@@ -3249,51 +3426,50 @@ msgid "flunk 'Not done testing yet.'"
 msgstr ""
 
 # Test::Unit::Assertions#assert_not_same
-# Test::Unit::Assertions#refute_same
-msgid "Passes if ! +actual+ .equal? +expected+"
+msgid "Passes if ! `actual` .equal? `expected`"
 msgstr ""
 
 # @example
 msgid "assert_not_same Object.new, Object.new"
 msgstr ""
 
+#, fuzzy
 msgid ""
-"Passes if ! +actual+ .equal? +expected+\n"
+"Passes if ! `actual` .equal? `expected`\n"
 "Just for minitest compatibility. :<"
-msgstr ""
+msgstr "minitestとの互換製のためだけのリリースです。 :"
 
 # Test::Unit::Assertions#assert_not_equal
-# Test::Unit::Assertions#refute_equal
-msgid "Passes if +expected+ != +actual+"
+msgid "Passes if `expected` != `actual`"
 msgstr ""
 
 # @example
 msgid "assert_not_equal 'some string', 5"
 msgstr ""
 
+#, fuzzy
 msgid ""
-"Passes if +expected+ != +actual+\n"
+"Passes if `expected` != `actual`\n"
 "Just for minitest compatibility. :<"
-msgstr ""
+msgstr "minitestとの互換製のためだけのリリースです。 :"
 
 # Test::Unit::Assertions#assert_not_nil
-# Test::Unit::Assertions#refute_nil
-msgid "Passes if ! +object+ .nil?"
+msgid "Passes if ! `object` .nil?"
 msgstr ""
 
 # @example
 msgid "assert_not_nil '1 two 3'.sub!(/two/, '2')"
 msgstr ""
 
+#, fuzzy
 msgid ""
-"Passes if ! +object+ .nil?\n"
+"Passes if ! `object` .nil?\n"
 "Just for minitest compatibility. :<"
-msgstr ""
+msgstr "minitestとの互換製のためだけのリリースです。 :"
 
 # Test::Unit::Assertions#assert_no_match
 # Test::Unit::Assertions#assert_not_match
-# Test::Unit::Assertions#refute_match
-msgid "Passes if +regexp+ !~ +string+"
+msgid "Passes if `regexp` !~ `string`"
 msgstr ""
 
 # @example
@@ -3302,10 +3478,11 @@ msgid ""
 "assert_not_match(/three/, 'one 2 three') # -> fail"
 msgstr ""
 
+#, fuzzy
 msgid ""
-"Passes if +regexp+ !~ +string+\n"
+"Passes if `regexp` !~ `string`\n"
 "Just for minitest compatibility. :<"
-msgstr ""
+msgstr "minitestとの互換製のためだけのリリースです。 :"
 
 # Test::Unit::Assertions#assert_no_match
 msgid "Deprecated. Use #assert_not_match instead."
@@ -3321,6 +3498,10 @@ msgstr ""
 msgid "a new instance of ThrowTagExtractor"
 msgstr ""
 
+# Test::Unit::Assertions#assert_throw
+msgid "Passes if the block throws `expected_object`"
+msgstr ""
+
 # @example
 msgid ""
 "assert_throw(:done) do\n"
@@ -3328,9 +3509,14 @@ msgid ""
 "end"
 msgstr ""
 
-# Test::Unit::Assertions#assert_throw
-# Test::Unit::Assertions#assert_throws
-msgid "Passes if the block throws +expected_object+"
+#, fuzzy
+msgid ""
+"Passes if the block throws `expected_object`\n"
+"Just for minitest compatibility. :<"
+msgstr "minitestとの互換製のためだけのリリースです。 :"
+
+# Test::Unit::Assertions#assert_nothing_thrown
+msgid "Passes if block does not throw anything."
 msgstr ""
 
 # @example
@@ -3340,17 +3526,20 @@ msgid ""
 "end"
 msgstr ""
 
+# Test::Unit::Assertions#assert_in_delta
+msgid ""
+"Passes if `expected_float` and `actual_float` are equal\n"
+"within `delta` tolerance."
+msgstr ""
+
 # @example
 msgid "assert_in_delta 0.05, (50000.0 / 10**6), 0.00001"
 msgstr ""
 
+# Test::Unit::Assertions#assert_not_in_delta
 msgid ""
-"Passes if the block throws +expected_object+\n"
-"Just for minitest compatibility. :<"
-msgstr ""
-
-# Test::Unit::Assertions#assert_nothing_thrown
-msgid "Passes if block does not throw anything."
+"Passes if `expected_float` and `actual_float` are\n"
+"not equal within `delta` tolerance."
 msgstr ""
 
 # @example
@@ -3359,23 +3548,17 @@ msgid ""
 "assert_not_in_delta(0.05, (50000.0 / 10**6), 0.00001) # -> fail"
 msgstr ""
 
-# Test::Unit::Assertions#assert_in_delta
+#, fuzzy
 msgid ""
-"Passes if +expected_float+ and +actual_float+ are equal\n"
-"within +delta+ tolerance."
-msgstr ""
-
-# Test::Unit::Assertions#assert_not_in_delta
-# Test::Unit::Assertions#refute_in_delta
-msgid ""
-"Passes if +expected_float+ and +actual_float+ are\n"
-"not equal within +delta+ tolerance."
-msgstr ""
-
-msgid ""
-"Passes if +expected_float+ and +actual_float+ are\n"
-"not equal within +delta+ tolerance.\n"
+"Passes if `expected_float` and `actual_float` are\n"
+"not equal within `delta` tolerance.\n"
 "Just for minitest compatibility. :<"
+msgstr "minitestとの互換製のためだけのリリースです。 :"
+
+# Test::Unit::Assertions#assert_in_epsilon
+msgid ""
+"Passes if `expected_float` and `actual_float` are equal\n"
+"within `epsilon` relative error of `expected_float`."
 msgstr ""
 
 # @example
@@ -3384,31 +3567,38 @@ msgid ""
 "assert_in_epsilon(10000.0, 9899.0, 0.1) # -> fail"
 msgstr ""
 
+# Test::Unit::Assertions#assert_not_in_epsilon
+msgid ""
+"Passes if `expected_float` and `actual_float` are\n"
+"not equal within `epsilon` relative error of\n"
+"`expected_float`."
+msgstr ""
+
 # @example
 msgid ""
 "assert_not_in_epsilon(10000.0, 9900.0, 0.1) # -> fail\n"
 "assert_not_in_epsilon(10000.0, 9899.0, 0.1) # -> pass"
 msgstr ""
 
-# Test::Unit::Assertions#assert_in_epsilon
+#, fuzzy
 msgid ""
-"Passes if +expected_float+ and +actual_float+ are equal\n"
-"within +epsilon+ relative error of +expected_float+."
-msgstr ""
-
-# Test::Unit::Assertions#assert_not_in_epsilon
-# Test::Unit::Assertions#refute_in_epsilon
-msgid ""
-"Passes if +expected_float+ and +actual_float+ are\n"
-"not equal within +epsilon+ relative error of\n"
-"+expected_float+."
-msgstr ""
-
-msgid ""
-"Passes if +expected_float+ and +actual_float+ are\n"
-"not equal within +epsilon+ relative error of\n"
-"+expected_float+.\n"
+"Passes if `expected_float` and `actual_float` are\n"
+"not equal within `epsilon` relative error of\n"
+"`expected_float`.\n"
 "Just for minitest compatibility. :<"
+msgstr "minitestとの互換製のためだけのリリースです。 :"
+
+# Test::Unit::Assertions#assert_send
+msgid "Passes if the method send returns a true value."
+msgstr ""
+
+# Test::Unit::Assertions#assert_not_send
+# Test::Unit::Assertions#assert_send
+msgid ""
+"`send_array` is composed of:\n"
+"* A receiver\n"
+"* A method\n"
+"* Arguments to the method"
 msgstr ""
 
 # @example
@@ -3417,16 +3607,7 @@ msgid ""
 "assert_send([[1, 2], :member?, 4]) # -> fail"
 msgstr ""
 
-# Test::Unit::Assertions#assert_send
-msgid "Passes if the method send returns a true value."
-msgstr ""
-
-# Test::Unit::Assertions#assert_not_send
-msgid ""
-"+send_array+ is composed of:\n"
-"* A receiver\n"
-"* A method\n"
-"* Arguments to the method"
+msgid "Passes if the method send doesn't return a true value."
 msgstr ""
 
 # @example
@@ -3435,7 +3616,8 @@ msgid ""
 "assert_not_send([[1, 2], :member?, 4]) # -> pass"
 msgstr ""
 
-msgid "Passes if the method send doesn't return a true value."
+# Test::Unit::Assertions#assert_boolean
+msgid "Passes if `actual` is a boolean value."
 msgstr ""
 
 # @example
@@ -3444,10 +3626,18 @@ msgid ""
 "assert_boolean(nil)  # -> fail"
 msgstr ""
 
+# Test::Unit::Assertions#assert_true
+msgid "Passes if `actual` is true."
+msgstr ""
+
 # @example
 msgid ""
 "assert_true(true)  # -> pass\n"
 "assert_true(:true) # -> fail"
+msgstr ""
+
+# Test::Unit::Assertions#assert_false
+msgid "Passes if `actual` is false."
 msgstr ""
 
 # @example
@@ -3456,8 +3646,10 @@ msgid ""
 "assert_false(nil)    # -> fail"
 msgstr ""
 
-# Test::Unit::Assertions#assert_boolean
-msgid "Passes if +actual+ is a boolean value."
+# Test::Unit::Assertions#assert_compare
+msgid ""
+"Passes if expression \"`expected` `operator`\n"
+"`actual`\" is true."
 msgstr ""
 
 # @example
@@ -3466,12 +3658,7 @@ msgid ""
 "assert_compare(1, \">=\", 10) # -> fail"
 msgstr ""
 
-# Test::Unit::Assertions#assert_true
-msgid "Passes if +actual+ is true."
-msgstr ""
-
-# Test::Unit::Assertions#assert_false
-msgid "Passes if +actual+ is false."
+msgid "Passes if assertion is failed in block."
 msgstr ""
 
 # @example
@@ -3480,10 +3667,10 @@ msgid ""
 "assert_fail_assertion {assert_equal(\"A\", \"A\")}  # -> fail"
 msgstr ""
 
-# Test::Unit::Assertions#assert_compare
+# Test::Unit::Assertions#assert_raise_message
 msgid ""
-"Passes if expression \"+expected+ +operator+\n"
-"+actual+\" is true."
+"Passes if an exception is raised in block and its\n"
+"message is `expected`."
 msgstr ""
 
 # @example
@@ -3494,13 +3681,8 @@ msgid ""
 "assert_raise_message(\"exception\") {}                   # -> fail"
 msgstr ""
 
-msgid "Passes if assertion is failed in block."
-msgstr ""
-
-# Test::Unit::Assertions#assert_raise_message
-msgid ""
-"Passes if an exception is raised in block and its\n"
-"message is +expected+."
+# Test::Unit::Assertions#assert_const_defined
+msgid "Passes if `object`.const_defined?(`constant_name`)"
 msgstr ""
 
 # @example
@@ -3509,10 +3691,18 @@ msgid ""
 "assert_const_defined(Object, :Nonexistent) # -> fail"
 msgstr ""
 
+# Test::Unit::Assertions#assert_not_const_defined
+msgid "Passes if !`object`.const_defined?(`constant_name`)"
+msgstr ""
+
 # @example
 msgid ""
 "assert_not_const_defined(Object, :Nonexistent) # -> pass\n"
 "assert_not_const_defined(Test, :Unit)          # -> fail"
+msgstr ""
+
+# Test::Unit::Assertions#assert_predicate
+msgid "Passes if `object`.`predicate` is _true_."
 msgstr ""
 
 # @example
@@ -3521,12 +3711,8 @@ msgid ""
 "assert_predicate([1], :empty?) # -> fail"
 msgstr ""
 
-# Test::Unit::Assertions#assert_const_defined
-msgid "Passes if +object+.const_defined?(+constant_name+)"
-msgstr ""
-
-# Test::Unit::Assertions#assert_not_const_defined
-msgid "Passes if !+object+.const_defined?(+constant_name+)"
+# Test::Unit::Assertions#assert_not_predicate
+msgid "Passes if `object`.`predicate` is not _true_."
 msgstr ""
 
 # @example
@@ -3535,8 +3721,16 @@ msgid ""
 "assert_not_predicate([], :empty?)  # -> fail"
 msgstr ""
 
-# Test::Unit::Assertions#assert_predicate
-msgid "Passes if +object+.+predicate+ is _true_."
+#, fuzzy
+msgid ""
+"Passes if `object`.`predicate` is not _true_.\n"
+"Just for minitest compatibility. :<"
+msgstr "minitestとの互換製のためだけのリリースです。 :"
+
+# Test::Unit::Assertions#assert_alias_method
+msgid ""
+"Passes if `object`#`alias_name` is an alias method of\n"
+"`object`#`original_name`."
 msgstr ""
 
 # @example
@@ -3546,19 +3740,8 @@ msgid ""
 "assert_alias_method([], :each, :size)    # -> fail"
 msgstr ""
 
-# Test::Unit::Assertions#assert_not_predicate
-msgid "Passes if +object+.+predicate+ is not _true_."
-msgstr ""
-
-msgid ""
-"Passes if +object+.+predicate+ is not _true_.\n"
-"Just for minitest compatibility. :<"
-msgstr ""
-
-# Test::Unit::Assertions#assert_alias_method
-msgid ""
-"Passes if +object+#+alias_name+ is an alias method of\n"
-"+object+#+original_name+."
+# Test::Unit::Assertions#assert_path_exist
+msgid "Passes if `path` exists."
 msgstr ""
 
 # @example
@@ -3568,6 +3751,10 @@ msgid ""
 "assert_path_exist(\"/nonexistent\")  # -> fail"
 msgstr ""
 
+# Test::Unit::Assertions#assert_path_not_exist
+msgid "Passes if `path` doesn't exist."
+msgstr ""
+
 # @example
 msgid ""
 "assert_path_not_exist(\"/nonexistent\")  # -> pass\n"
@@ -3575,8 +3762,8 @@ msgid ""
 "assert_path_not_exist(\"/bin/sh\")       # -> fail"
 msgstr ""
 
-# Test::Unit::Assertions#assert_path_exist
-msgid "Passes if +path+ exists."
+# Test::Unit::Assertions#assert_include
+msgid "Passes if `collection` includes `object`."
 msgstr ""
 
 # @example
@@ -3587,8 +3774,14 @@ msgid ""
 "assert_include(1..10, 20)             # -> fail"
 msgstr ""
 
-# Test::Unit::Assertions#assert_path_not_exist
-msgid "Passes if +path+ doesn't exist."
+#, fuzzy
+msgid ""
+"Passes if `collection` includes `object`.\n"
+"Just for minitest compatibility. :<"
+msgstr "minitestとの互換製のためだけのリリースです。 :"
+
+# Test::Unit::Assertions#assert_not_include
+msgid "Passes if `collection` doesn't include `object`."
 msgstr ""
 
 # @example
@@ -3599,14 +3792,14 @@ msgid ""
 "assert_not_include(1..10, 5)              # -> fail"
 msgstr ""
 
-# Test::Unit::Assertions#assert_include
-# Test::Unit::Assertions#assert_includes
-msgid "Passes if +collection+ includes +object+."
-msgstr ""
-
+#, fuzzy
 msgid ""
-"Passes if +collection+ includes +object+.\n"
+"Passes if `collection` doesn't include `object`.\n"
 "Just for minitest compatibility. :<"
+msgstr "minitestとの互換製のためだけのリリースです。 :"
+
+# Test::Unit::Assertions#assert_empty
+msgid "Passes if `object` is empty."
 msgstr ""
 
 # @example
@@ -3619,8 +3812,8 @@ msgid ""
 "assert_empty({1 => 2})                 # -> fail"
 msgstr ""
 
-# Test::Unit::Assertions#assert_not_include
-msgid "Passes if +collection+ doesn't include +object+."
+# Test::Unit::Assertions#assert_not_empty
+msgid "Passes if `object` is not empty."
 msgstr ""
 
 # @example
@@ -3633,29 +3826,18 @@ msgid ""
 "assert_not_empty({})                       # -> fail"
 msgstr ""
 
+#, fuzzy
 msgid ""
-"Passes if +collection+ doesn't include +object+.\n"
+"Passes if `object` is not empty.\n"
 "Just for minitest compatibility. :<"
-msgstr ""
+msgstr "minitestとの互換製のためだけのリリースです。 :"
 
-# Test::Unit::Assertions#assert_empty
-msgid "Passes if +object+ is empty."
-msgstr ""
-
-# Test::Unit::Assertions#assert_not_empty
-msgid "Passes if +object+ is not empty."
-msgstr ""
-
+#, fuzzy
 msgid ""
-"Passes if +object+ is not empty.\n"
-"Just for minitest compatibility. :<"
-msgstr ""
-
-# Test::Unit::Assertions#build_message
-msgid ""
-"Builds a failure message.  +head+ is added before the +template+ and\n"
-"+arguments+ replaces the '?'s positionally in the template."
-msgstr ""
+"Builds a failure message.  `user_message` is added before the\n"
+"`template` and `arguments` replaces the '?'s positionally in\n"
+"the template."
+msgstr "修正前"
 
 # Test::Unit::Assertions#add_assertion
 msgid ""
@@ -3738,6 +3920,10 @@ msgstr ""
 
 # @return [AttributeMatcher]
 msgid "a new instance of AttributeMatcher"
+msgstr ""
+
+# Test::Unit::Attribute::ClassMethods#attribute
+msgid "Set an attribute to test methods."
 msgstr ""
 
 # @overload
@@ -3823,10 +4009,6 @@ msgstr ""
 msgid "ignored"
 msgstr ""
 
-# Test::Unit::Attribute::ClassMethods#attribute
-msgid "Set an attribute to test methods."
-msgstr ""
-
 msgid "Returns the value of attribute suite"
 msgstr ""
 
@@ -3839,6 +4021,33 @@ msgstr ""
 
 # @param value
 msgid "the value to set the attribute to_run to."
+msgstr ""
+
+msgid "Returns the value of attribute filters"
+msgstr ""
+
+# Test::Unit::AutoRunner#filters=
+msgid "Sets the attribute filters"
+msgstr ""
+
+msgid "Returns the value of attribute to_run"
+msgstr ""
+
+# Test::Unit::AutoRunner#to_run=
+msgid "Sets the attribute to_run"
+msgstr ""
+
+# @param value
+msgid "the value to set the attribute default_test_paths to."
+msgstr ""
+
+# Test::Unit::AutoRunner#default_test_paths
+# Test::Unit::Collector::Load#default_test_paths
+msgid "Returns the value of attribute default_test_paths"
+msgstr ""
+
+# Test::Unit::AutoRunner#default_test_paths=
+msgid "Sets the attribute default_test_paths"
 msgstr ""
 
 # @param value
@@ -3855,20 +4064,6 @@ msgstr ""
 
 # @param value
 msgid "the value to set the attribute workdir to."
-msgstr ""
-
-msgid "Returns the value of attribute filters"
-msgstr ""
-
-# Test::Unit::AutoRunner#filters=
-msgid "Sets the attribute filters"
-msgstr ""
-
-msgid "Returns the value of attribute to_run"
-msgstr ""
-
-# Test::Unit::AutoRunner#to_run=
-msgid "Sets the attribute to_run"
 msgstr ""
 
 msgid "Returns the value of attribute pattern"
@@ -3920,6 +4115,14 @@ msgstr ""
 msgid "Sets the attribute listeners"
 msgstr ""
 
+# @param value
+msgid "the value to set the attribute stop_on_failure to."
+msgstr ""
+
+# Test::Unit::AutoRunner#stop_on_failure=
+msgid "Sets the attribute stop_on_failure"
+msgstr ""
+
 msgid "the value to set the attribute runner to."
 msgstr ""
 
@@ -3940,27 +4143,6 @@ msgid "tag|yieldparam|_self"
 msgstr ""
 
 msgid "the object that the method was called on"
-msgstr ""
-
-# @param value
-msgid "the value to set the attribute default_test_paths to."
-msgstr ""
-
-# Test::Unit::AutoRunner#default_test_paths
-# Test::Unit::Collector::Load#default_test_paths
-msgid "Returns the value of attribute default_test_paths"
-msgstr ""
-
-# Test::Unit::AutoRunner#default_test_paths=
-msgid "Sets the attribute default_test_paths"
-msgstr ""
-
-# @param value
-msgid "the value to set the attribute stop_on_failuere to."
-msgstr ""
-
-# Test::Unit::AutoRunner#stop_on_failuere=
-msgid "Sets the attribute stop_on_failuere"
 msgstr ""
 
 # @return [CodeSnippetFetcher]
@@ -4007,6 +4189,10 @@ msgstr ""
 msgid "a new instance of MixColor"
 msgstr ""
 
+# @return [DataSets]
+msgid "a new instance of DataSets"
+msgstr ""
+
 msgid "This method provides Data-Driven-Test functionality."
 msgstr "データ駆動テスト機能のドキュメントを追加しました。"
 
@@ -4016,6 +4202,20 @@ msgstr ""
 
 # @overload
 msgid "tag|overload|data"
+msgstr ""
+
+# @example
+msgid "tag|example|data(label, data)"
+msgstr ""
+
+# @example data(label, data)
+msgid ""
+"data(\"empty string\", [true, \"\"])\n"
+"data(\"plain string\", [false, \"hello\"])\n"
+"def test_empty?(data)\n"
+"  expected, target = data\n"
+"  assert_equal(expected, target.empty?)\n"
+"end"
 msgstr ""
 
 # @param [String]
@@ -4034,28 +4234,46 @@ msgstr ""
 msgid "specify test data."
 msgstr ""
 
-# @example
-msgid "tag|example|data(label, data)"
+# @param [Hash] options
+msgid "specify options."
 msgstr ""
 
-# @example data(label, data)
+# @example
+msgid "tag|example|data(variable, patterns)"
+msgstr ""
+
+# @example data(variable, patterns)
 msgid ""
-"data(\"empty string\", [true, \"\"])\n"
-"data(\"plain string\", [false, \"hello\"])\n"
-"def test_empty?(data)\n"
-"  expected, target = data\n"
-"  assert_equal(expected, target.empty?)\n"
+"data(:x, [1, 2, 3])\n"
+"data(:y, [\"a\", \"b\"])\n"
+"def test_patterns(data)\n"
+"  # 3 * 2 times executed\n"
+"  # 3: the number of patterns of :x\n"
+"  # 2: the number of patterns of :y\n"
+"  p data\n"
+"    # => {:x => 1, :y => \"a\"}\n"
+"    # => {:x => 1, :y => \"b\"}\n"
+"    # => {:x => 2, :y => \"a\"}\n"
+"    # => {:x => 2, :y => \"b\"}\n"
+"    # => {:x => 3, :y => \"a\"}\n"
+"    # => {:x => 3, :y => \"b\"}\n"
 "end"
 msgstr ""
 
-# @param [Hash]
-msgid "tag|param|data_set"
+# @param [Symbol]
+msgid "tag|param|variable"
 msgstr ""
 
-# @param [Hash] data_set
-msgid ""
-"specify test data as a Hash that\n"
-"key is test label and value is test data."
+# @param [Symbol] variable
+msgid "specify test pattern variable name."
+msgstr ""
+
+# @param [Array]
+msgid "tag|param|patterns"
+msgstr ""
+
+# @param [Array] patterns
+msgid "specify test patterns for the variable."
 msgstr ""
 
 # @example
@@ -4072,9 +4290,13 @@ msgid ""
 "end"
 msgstr ""
 
-# @yieldreturn [Hash]
+# @param [Hash]
+msgid "tag|param|data_set"
+msgstr ""
+
+# @param [Hash] data_set
 msgid ""
-"return test data set as a Hash that\n"
+"specify test data as a Hash that\n"
 "key is test label and value is test data."
 msgstr ""
 
@@ -4096,27 +4318,56 @@ msgid ""
 "end"
 msgstr ""
 
+# @yieldreturn [Hash<String, Object>]
+msgid ""
+"return test data set\n"
+"as a Hash that key is test label and value is test data."
+msgstr ""
+
+# @example data(&block)
+msgid ""
+"data do\n"
+"  patterns = 3.times.to_a\n"
+"  [:x, patterns]\n"
+"end\n"
+"data do\n"
+"  patterns = []\n"
+"  character = \"a\"\n"
+"  2.times.each do\n"
+"    patterns << character\n"
+"    character = character.succ\n"
+"  end\n"
+"  [:y, patterns]\n"
+"end\n"
+"def test_patterns(data)\n"
+"  # 3 * 2 times executed\n"
+"  # 3: the number of patterns of :x\n"
+"  # 2: the number of patterns of :y\n"
+"  p data\n"
+"    # => {:x => 0, :y => \"a\"}\n"
+"    # => {:x => 0, :y => \"b\"}\n"
+"    # => {:x => 1, :y => \"a\"}\n"
+"    # => {:x => 1, :y => \"b\"}\n"
+"    # => {:x => 2, :y => \"a\"}\n"
+"    # => {:x => 2, :y => \"b\"}\n"
+"end"
+msgstr ""
+
+# @yieldreturn [Array<Symbol, Array>]
+msgid ""
+"return test data set\n"
+"as an Array of variable and patterns."
+msgstr ""
+
+# Test::Unit::Data::ClassMethods#data
+msgid "Generates test matrix from variable and patterns pairs."
+msgstr ""
+
 # Test::Unit::Data::ClassMethods#load_data
 msgid ""
 "Load test data from the file. This is shorthand to load\n"
 "test data from file.  If you want to load complex file, you\n"
 "can use {#data} with block."
-msgstr ""
-
-# @param [String]
-msgid "tag|param|file_name"
-msgstr ""
-
-msgid ""
-"full path to test data file.\n"
-"File format is automatically detected from filename extension."
-msgstr "データファイルのフルパスを指定します。ファイルフォーマットはファイルの拡張子から自動的に判別します。"
-
-msgid "if +file_name+ is not supported file format."
-msgstr "+file_name+ がサポートされていないファイルフォーマットのときに発生します。"
-
-# @see
-msgid "tag|see|Loader#load"
 msgstr ""
 
 msgid "tag|example|Load data from CSV file"
@@ -4128,6 +4379,23 @@ msgid ""
 "def test_empty?(data)\n"
 "  assert_equal(data[\"expected\"], data[\"target\"].empty?)\n"
 "end"
+msgstr ""
+
+# @param [String]
+msgid "tag|param|file_name"
+msgstr ""
+
+msgid ""
+"full path to test data file.\n"
+"File format is automatically detected from filename extension."
+msgstr "データファイルのフルパスを指定します。ファイルフォーマットはファイルの拡張子から自動的に判別します。"
+
+#, fuzzy
+msgid "if `file_name` is not supported file format."
+msgstr "+file_name+ がサポートされていないファイルフォーマットのときに発生します。"
+
+# @see
+msgid "tag|see|Loader#load"
 msgstr ""
 
 msgid "a new instance of Loader"
@@ -4442,21 +4710,26 @@ msgstr ""
 msgid "Notify some information."
 msgstr ""
 
-# Test::Unit::TestCaseNotificationSupport#notify
-msgid ""
-"Example:\n"
-"  def test_notification\n"
-"    notify(\"I'm here!\")\n"
-"    # Reached here\n"
-"    notify(\"Special!\") if special_case?\n"
-"    # Reached here too\n"
-"  end"
+# Test::Unit::TestCase
+msgid "Example:"
 msgstr ""
 
 # Test::Unit::TestCaseNotificationSupport#notify
 msgid ""
-"options:\n"
-"  :backtrace override backtrace."
+"    def test_notification\n"
+"      notify(\"I'm here!\")\n"
+"      # Reached here\n"
+"      notify(\"Special!\") if special_case?\n"
+"      # Reached here too\n"
+"    end"
+msgstr ""
+
+# Test::Unit::TestCaseNotificationSupport#notify
+msgid "options:"
+msgstr ""
+
+# Test::Unit::TestCaseNotificationSupport#notify
+msgid "    :backtrace override backtrace."
 msgstr ""
 
 msgid "Returns the value of attribute notifications"
@@ -4489,21 +4762,20 @@ msgstr ""
 
 # Test::Unit::TestCaseOmissionSupport#omit
 msgid ""
-"Example:\n"
-"  def test_omission\n"
-"    omit\n"
-"    # Not reached here\n"
-"  end"
+"    def test_omission\n"
+"      omit\n"
+"      # Not reached here\n"
+"    end"
 msgstr ""
 
 # Test::Unit::TestCaseOmissionSupport#omit
 msgid ""
-"  def test_omission_with_here\n"
-"    omit do\n"
-"      # Not ran here\n"
-"    end\n"
-"    # Reached here\n"
-"  end"
+"    def test_omission_with_here\n"
+"      omit do\n"
+"        # Not ran here\n"
+"      end\n"
+"      # Reached here\n"
+"    end"
 msgstr ""
 
 # Test::Unit::TestCaseOmissionSupport#omit_if
@@ -4514,24 +4786,23 @@ msgstr ""
 
 # Test::Unit::TestCaseOmissionSupport#omit_if
 msgid ""
-"Example:\n"
-"  def test_omission\n"
-"    omit_if(\"\".empty?)\n"
-"    # Not reached here\n"
-"  end"
+"    def test_omission\n"
+"      omit_if(\"\".empty?)\n"
+"      # Not reached here\n"
+"    end"
 msgstr ""
 
 # Test::Unit::TestCaseOmissionSupport#omit_if
 msgid ""
-"  def test_omission_with_here\n"
-"    omit_if(true) do\n"
-"      # Not ran here\n"
-"    end\n"
-"    omit_if(false) do\n"
-"      # Reached here\n"
-"    end\n"
-"    # Reached here too\n"
-"  end"
+"    def test_omission_with_here\n"
+"      omit_if(true) do\n"
+"        # Not ran here\n"
+"      end\n"
+"      omit_if(false) do\n"
+"        # Reached here\n"
+"      end\n"
+"      # Reached here too\n"
+"    end"
 msgstr ""
 
 # Test::Unit::TestCaseOmissionSupport#omit_unless
@@ -4542,24 +4813,23 @@ msgstr ""
 
 # Test::Unit::TestCaseOmissionSupport#omit_unless
 msgid ""
-"Example:\n"
-"  def test_omission\n"
-"    omit_unless(\"string\".empty?)\n"
-"    # Not reached here\n"
-"  end"
+"    def test_omission\n"
+"      omit_unless(\"string\".empty?)\n"
+"      # Not reached here\n"
+"    end"
 msgstr ""
 
 # Test::Unit::TestCaseOmissionSupport#omit_unless
 msgid ""
-"  def test_omission_with_here\n"
-"    omit_unless(true) do\n"
-"      # Reached here\n"
-"    end\n"
-"    omit_unless(false) do\n"
-"      # Not ran here\n"
-"    end\n"
-"    # Reached here too\n"
-"  end"
+"    def test_omission_with_here\n"
+"      omit_unless(true) do\n"
+"        # Reached here\n"
+"      end\n"
+"      omit_unless(false) do\n"
+"        # Not ran here\n"
+"      end\n"
+"      # Reached here too\n"
+"    end"
 msgstr ""
 
 msgid "Returns the value of attribute omissions"
@@ -4591,23 +4861,22 @@ msgstr ""
 
 # Test::Unit::TestCasePendingSupport#pend
 msgid ""
-"Example:\n"
-"  def test_pending\n"
-"    pend\n"
-"    # Not reached here\n"
-"  end"
+"    def test_pending\n"
+"      pend\n"
+"      # Not reached here\n"
+"    end"
 msgstr ""
 
 # Test::Unit::TestCasePendingSupport#pend
 msgid ""
-"  def test_pending_with_here\n"
-"    pend do\n"
-"      # Ran here\n"
-"      # Fails if the block doesn't raise any error.\n"
-"      # Because it means the block is passed unexpectedly.\n"
-"    end\n"
-"    # Reached here\n"
-"  end"
+"    def test_pending_with_here\n"
+"      pend do\n"
+"        # Ran here\n"
+"        # Fails if the block doesn't raise any error.\n"
+"        # Because it means the block is passed unexpectedly.\n"
+"      end\n"
+"      # Reached here\n"
+"    end"
 msgstr ""
 
 msgid "Returns the value of attribute pendings"
@@ -4633,9 +4902,6 @@ msgstr ""
 msgid "a new instance of TestSuiteCreator"
 msgstr ""
 
-msgid ":nodoc:"
-msgstr ""
-
 # Test::Unit::TestCase
 msgid ""
 "Ties everything together. If you subclass and add your own\n"
@@ -4646,10 +4912,6 @@ msgid ""
 msgstr ""
 
 msgid "You can run two hooks before/after a TestCase run."
-msgstr ""
-
-# Test::Unit::TestCase
-msgid "Example:"
 msgstr ""
 
 # Test::Unit::TestCase
@@ -4703,10 +4965,6 @@ msgid ""
 "        ...\n"
 "      end\n"
 "    end"
-msgstr ""
-
-# Test::Unit::TestCase
-msgid "Here is a call order:"
 msgstr ""
 
 # Test::Unit::TestCase
@@ -4764,43 +5022,33 @@ msgstr ""
 
 # Test::Unit::TestCase.startup
 msgid ""
-"Here is an example test case:\n"
-"  class TestMyClass < Test::Unit::TestCase\n"
-"    class << self\n"
-"      def startup\n"
+"    class TestMyClass < Test::Unit::TestCase\n"
+"      class << self\n"
+"        def startup\n"
+"          ...\n"
+"        end\n"
+"      end"
+msgstr ""
+
+# Test::Unit::TestCase.shutdown
+# Test::Unit::TestCase.startup
+msgid ""
+"      def test_my_class1\n"
+"        ...\n"
+"      end"
+msgstr ""
+
+# Test::Unit::TestCase.shutdown
+# Test::Unit::TestCase.startup
+msgid ""
+"      def test_my_class2\n"
 "        ...\n"
 "      end\n"
 "    end"
 msgstr ""
 
-# Test::Unit::TestCase
 # Test::Unit::TestCase.startup
 msgid ""
-"    def setup\n"
-"      ...\n"
-"    end"
-msgstr ""
-
-# Test::Unit::TestCase.shutdown
-# Test::Unit::TestCase.startup
-msgid ""
-"    def test_my_class1\n"
-"      ...\n"
-"    end"
-msgstr ""
-
-# Test::Unit::TestCase.shutdown
-# Test::Unit::TestCase.startup
-msgid ""
-"    def test_my_class2\n"
-"      ...\n"
-"    end\n"
-"  end"
-msgstr ""
-
-# Test::Unit::TestCase.startup
-msgid ""
-"Here is a call order:\n"
 "* startup\n"
 "* setup\n"
 "* test_my_class1 (or test_my_class2)\n"
@@ -4823,26 +5071,16 @@ msgstr ""
 
 # Test::Unit::TestCase.shutdown
 msgid ""
-"Here is an example test case:\n"
-"  class TestMyClass < Test::Unit::TestCase\n"
-"    class << self\n"
-"      def shutdown\n"
-"        ...\n"
-"      end\n"
-"    end"
-msgstr ""
-
-# Test::Unit::TestCase
-# Test::Unit::TestCase.shutdown
-msgid ""
-"    def teardown\n"
-"      ...\n"
-"    end"
+"    class TestMyClass < Test::Unit::TestCase\n"
+"      class << self\n"
+"        def shutdown\n"
+"          ...\n"
+"        end\n"
+"      end"
 msgstr ""
 
 # Test::Unit::TestCase.shutdown
 msgid ""
-"Here is a call order:\n"
 "* test_my_class1 (or test_my_class2)\n"
 "* teardown\n"
 "* test_my_class2 (or test_my_class1)\n"
@@ -4853,21 +5091,32 @@ msgstr ""
 # Test::Unit::TestCase.test_order
 msgid ""
 "Returns the current test order. This returns\n"
-"+:alphabetic+ by default."
+"`:alphabetic` by default."
 msgstr ""
 
 msgid "Sets the current test order."
 msgstr ""
 
 # Test::Unit::TestCase.test_order=
+msgid "Here are the available _order_:"
+msgstr ""
+
+# Test::Unit::TestCase.test_order=
 msgid ""
-"Here are the available _order_:\n"
-"[:alphabetic]\n"
-"  Default. Tests are sorted in alphabetic order.\n"
-"[:random]\n"
-"  Tests are sorted in random order.\n"
-"[:defined]\n"
-"  Tests are sorted in defined order."
+":alphabetic\n"
+": Default. Tests are sorted in alphabetic order."
+msgstr ""
+
+# Test::Unit::TestCase.test_order=
+msgid ""
+":random\n"
+": Tests are sorted in random order."
+msgstr ""
+
+# Test::Unit::TestCase.test_order=
+msgid ""
+":defined\n"
+": Tests are sorted in defined order."
 msgstr ""
 
 # Test::Unit::TestCase.test
@@ -4884,17 +5133,17 @@ msgstr ""
 
 # Test::Unit::TestCase.test
 msgid ""
-"  description \"register user\"\n"
-"  def test_register_user\n"
-"    ...\n"
-"  end"
+"    description \"register user\"\n"
+"    def test_register_user\n"
+"      ...\n"
+"    end"
 msgstr ""
 
 # Test::Unit::TestCase.test
 msgid ""
-"  test \"register user\" do\n"
-"    ...\n"
-"  end"
+"    test \"register user\" do\n"
+"      ...\n"
+"    end"
 msgstr ""
 
 # Test::Unit::TestCase.test
@@ -4905,10 +5154,10 @@ msgstr ""
 
 # Test::Unit::TestCase.test
 msgid ""
-"  test\n"
-"  def my_test_method\n"
-"    assert_equal(\"call me\", ...)\n"
-"  end"
+"    test\n"
+"    def my_test_method\n"
+"      assert_equal(\"call me\", ...)\n"
+"    end"
 msgstr ""
 
 msgid "Describes a test."
@@ -4923,25 +5172,13 @@ msgstr ""
 
 # Test::Unit::TestCase.description
 msgid ""
-"  description \"register a normal user\"\n"
-"  def test_register\n"
-"    ...\n"
-"  end"
+"    description \"register a normal user\"\n"
+"    def test_register\n"
+"      ...\n"
+"    end"
 msgstr ""
 
 msgid "Defines a sub test case."
-msgstr ""
-
-msgid "The name of newly created sub test case."
-msgstr ""
-
-# @yield
-msgid ""
-"The block is evaluated under the newly created sub test\n"
-"case class context."
-msgstr ""
-
-msgid "Created sub test case class."
 msgstr ""
 
 # Test::Unit::TestCase.sub_test_case
@@ -4951,37 +5188,35 @@ msgid ""
 msgstr ""
 
 # Test::Unit::TestCase.sub_test_case
-msgid ""
-"Standard:\n"
-"  class TestParent < Test::Unit::TestCase\n"
-"    class TestChild < self\n"
-"      def test_in_child\n"
-"      end\n"
-"    end\n"
-"  end"
+msgid "Standard:"
 msgstr ""
 
 # Test::Unit::TestCase.sub_test_case
 msgid ""
-"Syntax sugar:\n"
-"  class TestParent < Test::Unit::TestCase\n"
-"    sub_test_case(\"TestChild\") do\n"
-"      def test_in_child\n"
+"    class TestParent < Test::Unit::TestCase\n"
+"      class TestChild < self\n"
+"        def test_in_child\n"
+"        end\n"
 "      end\n"
-"    end\n"
-"  end"
+"    end"
+msgstr ""
+
+# Test::Unit::TestCase.sub_test_case
+msgid "Syntax sugar:"
+msgstr ""
+
+# Test::Unit::TestCase.sub_test_case
+msgid ""
+"    class TestParent < Test::Unit::TestCase\n"
+"      sub_test_case(\"TestChild\") do\n"
+"        def test_in_child\n"
+"        end\n"
+"      end\n"
+"    end"
 msgstr ""
 
 # Test::Unit::TestCase.sub_test_case
 msgid "The difference of them are the following:"
-msgstr ""
-
-# @option
-msgid "tag|option|query"
-msgstr ""
-
-# @param [Hash]
-msgid "tag|param|query"
 msgstr ""
 
 # Test::Unit::TestCase.sub_test_case
@@ -4992,6 +5227,26 @@ msgid ""
 "  constant naming rule in Ruby. But the name of test case\n"
 "  created by {sub_test_case} doesn't need to follow the rule.\n"
 "  For example, you can use a space in name such as \"child test\"."
+msgstr ""
+
+msgid "The name of newly created sub test case."
+msgstr ""
+
+msgid "Created sub test case class."
+msgstr ""
+
+# @yield
+msgid ""
+"The block is evaluated under the newly created sub test\n"
+"case class context."
+msgstr ""
+
+# @option
+msgid "tag|option|query"
+msgstr ""
+
+# @param [Hash]
+msgid "tag|param|query"
 msgstr ""
 
 # Test::Unit::TestCase.test_defined?
@@ -5031,56 +5286,59 @@ msgstr ""
 # Test::Unit::TestCase#setup
 msgid ""
 "You can add additional setup tasks by the following\n"
-"code:\n"
-"  class TestMyClass < Test::Unit::TestCase\n"
-"    def setup\n"
-"      ...\n"
-"    end"
+"code:"
 msgstr ""
 
 # Test::Unit::TestCase#setup
 msgid ""
-"    setup\n"
-"    def my_setup1\n"
-"      ...\n"
-"    end"
+"    class TestMyClass < Test::Unit::TestCase\n"
+"      def setup\n"
+"        ...\n"
+"      end"
 msgstr ""
 
 # Test::Unit::TestCase#setup
 msgid ""
-"    setup do\n"
-"      ... # setup callback1\n"
-"    end"
+"      setup\n"
+"      def my_setup1\n"
+"        ...\n"
+"      end"
 msgstr ""
 
 # Test::Unit::TestCase#setup
 msgid ""
-"    setup\n"
-"    def my_setup2\n"
-"      ...\n"
-"    end"
+"      setup do\n"
+"        ... # setup callback1\n"
+"      end"
 msgstr ""
 
 # Test::Unit::TestCase#setup
 msgid ""
-"    setup do\n"
-"      ... # setup callback2\n"
-"    end"
+"      setup\n"
+"      def my_setup2\n"
+"        ...\n"
+"      end"
+msgstr ""
+
+# Test::Unit::TestCase#setup
+msgid ""
+"      setup do\n"
+"        ... # setup callback2\n"
+"      end"
 msgstr ""
 
 # Test::Unit::TestCase#cleanup
 # Test::Unit::TestCase#setup
 # Test::Unit::TestCase#teardown
 msgid ""
-"    def test_my_class\n"
-"      ...\n"
-"    end\n"
-"  end"
+"      def test_my_class\n"
+"        ...\n"
+"      end\n"
+"    end"
 msgstr ""
 
 # Test::Unit::TestCase#setup
 msgid ""
-"Here is a call order:\n"
 "* setup\n"
 "* my_setup1\n"
 "* setup callback1\n"
@@ -5100,46 +5358,49 @@ msgstr ""
 # Test::Unit::TestCase#cleanup
 msgid ""
 "You can add additional cleanup tasks by the following\n"
-"code:\n"
-"  class TestMyClass < Test::Unit::TestCase\n"
-"    def cleanup\n"
-"      ...\n"
-"    end"
+"code:"
 msgstr ""
 
 # Test::Unit::TestCase#cleanup
 msgid ""
-"    cleanup\n"
-"    def my_cleanup1\n"
-"      ...\n"
-"    end"
+"    class TestMyClass < Test::Unit::TestCase\n"
+"      def cleanup\n"
+"        ...\n"
+"      end"
 msgstr ""
 
 # Test::Unit::TestCase#cleanup
 msgid ""
-"    cleanup do\n"
-"      ... # cleanup callback1\n"
-"    end"
+"      cleanup\n"
+"      def my_cleanup1\n"
+"        ...\n"
+"      end"
 msgstr ""
 
 # Test::Unit::TestCase#cleanup
 msgid ""
-"    cleanup\n"
-"    def my_cleanup2\n"
-"      ...\n"
-"    end"
+"      cleanup do\n"
+"        ... # cleanup callback1\n"
+"      end"
 msgstr ""
 
 # Test::Unit::TestCase#cleanup
 msgid ""
-"    cleanup do\n"
-"      ... # cleanup callback2\n"
-"    end"
+"      cleanup\n"
+"      def my_cleanup2\n"
+"        ...\n"
+"      end"
 msgstr ""
 
 # Test::Unit::TestCase#cleanup
 msgid ""
-"Here is a call order:\n"
+"      cleanup do\n"
+"        ... # cleanup callback2\n"
+"      end"
+msgstr ""
+
+# Test::Unit::TestCase#cleanup
+msgid ""
 "* test_my_class\n"
 "* cleanup callback2\n"
 "* my_cleanup2\n"
@@ -5157,46 +5418,49 @@ msgstr ""
 # Test::Unit::TestCase#teardown
 msgid ""
 "You can add additional teardown tasks by the following\n"
-"code:\n"
-"  class TestMyClass < Test::Unit::TestCase\n"
-"    def teardown\n"
-"      ...\n"
-"    end"
+"code:"
 msgstr ""
 
 # Test::Unit::TestCase#teardown
 msgid ""
-"    teardown\n"
-"    def my_teardown1\n"
-"      ...\n"
-"    end"
+"    class TestMyClass < Test::Unit::TestCase\n"
+"      def teardown\n"
+"        ...\n"
+"      end"
 msgstr ""
 
 # Test::Unit::TestCase#teardown
 msgid ""
-"    teardown do\n"
-"      ... # teardown callback1\n"
-"    end"
+"      teardown\n"
+"      def my_teardown1\n"
+"        ...\n"
+"      end"
 msgstr ""
 
 # Test::Unit::TestCase#teardown
 msgid ""
-"    teardown\n"
-"    def my_teardown2\n"
-"      ...\n"
-"    end"
+"      teardown do\n"
+"        ... # teardown callback1\n"
+"      end"
 msgstr ""
 
 # Test::Unit::TestCase#teardown
 msgid ""
-"    teardown do\n"
-"      ... # teardown callback2\n"
-"    end"
+"      teardown\n"
+"      def my_teardown2\n"
+"        ...\n"
+"      end"
 msgstr ""
 
 # Test::Unit::TestCase#teardown
 msgid ""
-"Here is a call order:\n"
+"      teardown do\n"
+"        ... # teardown callback2\n"
+"      end"
+msgstr ""
+
+# Test::Unit::TestCase#teardown
+msgid ""
 "* test_my_class\n"
 "* teardown callback2\n"
 "* my_teardown2\n"
@@ -5209,7 +5473,13 @@ msgstr ""
 msgid ""
 "Returns a label of test data for the test. If the\n"
 "test isn't associated with any test data, it returns\n"
-"+nil+."
+"`nil`."
+msgstr ""
+
+# Test::Unit::TestCase#data
+msgid ""
+"Returns test data for the test. If the test isn't associated\n"
+"with any test data, it returns `nil`."
 msgstr ""
 
 # Test::Unit::TestCase#name
@@ -5246,24 +5516,6 @@ msgstr ""
 msgid "It's handy to be able to compare TestCase instances."
 msgstr ""
 
-msgid "Returns the value of attribute start_time"
-msgstr ""
-
-msgid "Returns the value of attribute elapsed_time"
-msgstr ""
-
-# Test::Unit::TestCase::InternalData#test_data_label
-msgid "Returns the value of attribute test_data_label"
-msgstr ""
-
-# Test::Unit::TestCase::InternalData#test_data
-msgid "Returns the value of attribute test_data"
-msgstr ""
-
-# @return [InternalData]
-msgid "a new instance of InternalData"
-msgstr ""
-
 msgid "Returns a Time at the test was started."
 msgstr ""
 
@@ -5296,6 +5548,24 @@ msgid ""
 "example, we may add a new hook in #run."
 msgstr ""
 
+msgid "Returns the value of attribute start_time"
+msgstr ""
+
+msgid "Returns the value of attribute elapsed_time"
+msgstr ""
+
+# Test::Unit::TestCase::InternalData#test_data_label
+msgid "Returns the value of attribute test_data_label"
+msgstr ""
+
+# Test::Unit::TestCase::InternalData#test_data
+msgid "Returns the value of attribute test_data"
+msgstr ""
+
+# @return [InternalData]
+msgid "a new instance of InternalData"
+msgstr ""
+
 # Test::Unit::TestResult
 msgid ""
 "Collects Test::Unit::Failure and Test::Unit::Error so that\n"
@@ -5320,10 +5590,6 @@ msgstr ""
 msgid "the value to set the attribute stop_tag to."
 msgstr ""
 
-# @return [TestResult]
-msgid "a new instance of TestResult"
-msgstr ""
-
 # Test::Unit::TestResult#stop_tag
 msgid "Returns the value of attribute stop_tag"
 msgstr ""
@@ -5333,6 +5599,10 @@ msgid "Sets the attribute stop_tag"
 msgstr ""
 
 msgid "Constructs a new, empty TestResult."
+msgstr ""
+
+# @return [TestResult]
+msgid "a new instance of TestResult"
 msgstr ""
 
 msgid "Records a test run."
@@ -5541,8 +5811,8 @@ msgstr ""
 
 # Test::Unit::Util::Observable#add_listener
 msgid ""
-" listener = add_listener(\"Channel\") { ... }\n"
-" remove_listener(\"Channel\", listener)"
+"    listener = add_listener(\"Channel\") { ... }\n"
+"    remove_listener(\"Channel\", listener)"
 msgstr ""
 
 # Test::Unit::Util::Observable#remove_listener
@@ -5576,11 +5846,10 @@ msgstr ""
 
 # Test::Unit::Util::Output#capture_output
 msgid ""
-"Example:\n"
-"  capture_output do\n"
-"    puts(\"stdout\")\n"
-"    warn(\"stderr\")\n"
-"  end # -> [\"stdout\n"
+"    capture_output do\n"
+"      puts(\"stdout\")\n"
+"      warn(\"stderr\")\n"
+"    end # -> [\"stdout\n"
 "\", \"stderr\n"
 "\"]"
 msgstr ""

--- a/lib/test/unit.rb
+++ b/lib/test/unit.rb
@@ -278,12 +278,17 @@ module Test # :nodoc:
   #      ...
   #    ...
   #
-  # SCHEME_NAME:: the name of the color scheme
-  # EVENT_NAME:: one of [success, failure, pending,
-  #              omission, notification, error]
-  # COLOR_NAME:: one of [black, red, green, yellow, blue,
-  #              magenta, cyan, white]
-  # BOOLEAN:: true or false
+  # SCHEME_NAME
+  # : the name of the color scheme
+  #
+  # EVENT_NAME
+  # : one of [success, failure, pending, omission, notification, error]
+  #
+  # COLOR_NAME
+  # : one of [black, red, green, yellow, blue, magenta, cyan, white]
+  #
+  # BOOLEAN
+  # : true or false
   #
   # You can use the above 'inverted' color scheme with the
   # following configuration:

--- a/lib/test/unit.rb
+++ b/lib/test/unit.rb
@@ -3,9 +3,9 @@ require 'test/unit/autorunner'
 
 module Test # :nodoc:
   #
-  # = Test::Unit - Ruby Unit Testing Framework
+  # # Test::Unit - Ruby Unit Testing Framework
   # 
-  # == Introduction
+  # ## Introduction
   # 
   # Unit testing is making waves all over the place, largely due to the
   # fact that it is a core practice of XP. While XP is great, unit testing
@@ -24,12 +24,12 @@ module Test # :nodoc:
   # have tests for it.
   # 
   # 
-  # == Notes
+  # ## Notes
   # 
   # Test::Unit has grown out of and superceded Lapidary.
   # 
   # 
-  # == Feedback
+  # ## Feedback
   # 
   # I like (and do my best to practice) XP, so I value early releases,
   # user feedback, and clean, simple, expressive code. There is always
@@ -43,7 +43,7 @@ module Test # :nodoc:
   # info is below.
   # 
   # 
-  # == Contact Information
+  # ## Contact Information
   # 
   # A lot of discussion happens about Ruby in general on the ruby-talk
   # mailing list (http://www.ruby-lang.org/en/ml.html), and you can ask
@@ -53,7 +53,7 @@ module Test # :nodoc:
   # at mailto:testunit@talbott.ws, and I'll do my best to help you out.
   # 
   # 
-  # == Credits
+  # ## Credits
   # 
   # I'd like to thank...
   # 
@@ -86,7 +86,7 @@ module Test # :nodoc:
   # My Creator, for giving me life, and giving it more abundantly.
   # 
   # 
-  # == License
+  # ## License
   # 
   # Test::Unit is copyright (c) 2000-2003 Nathaniel Talbott. It is free
   # software, and is distributed under the Ruby license. See the COPYING
@@ -98,7 +98,7 @@ module Test # :nodoc:
   # under the Ruby license and/or the PSF license. See the
   # COPYING file and PSFL file.
   # 
-  # == Warranty
+  # ## Warranty
   # 
   # This software is provided "as is" and without any express or
   # implied warranties, including, without limitation, the implied
@@ -106,14 +106,14 @@ module Test # :nodoc:
   # purpose.
   # 
   # 
-  # == Author
+  # ## Author
   # 
   # Nathaniel Talbott.
   # Copyright (c) 2000-2003, Nathaniel Talbott
   #
   # ----
   #
-  # = Usage
+  # # Usage
   #
   # The general idea behind unit testing is that you write a _test_
   # _method_ that makes certain _assertions_ about your code, working
@@ -125,7 +125,7 @@ module Test # :nodoc:
   # pieces.
   #
   #
-  # == Assertions
+  # ## Assertions
   #
   # These are the heart of the framework. Think of an assertion as a
   # statement of expected outcome, i.e. "I assert that x should be equal
@@ -137,7 +137,7 @@ module Test # :nodoc:
   # of the current assertions, see Test::Unit::Assertions.
   #
   #
-  # == Test Method & Test Fixture
+  # ## Test Method & Test Fixture
   #
   # Obviously, these assertions have to be called within a context that
   # knows about them and can do something meaningful with their
@@ -197,7 +197,7 @@ module Test # :nodoc:
   #     end
   #
   #
-  # == Test Runners
+  # ## Test Runners
   #
   # So, now you have this great test class, but you still
   # need a way to run it and view any failures that occur
@@ -211,7 +211,7 @@ module Test # :nodoc:
   #    require 'test/unit'
   #    Test::Unit::AutoRunner.default_runner = "gtk2"
   #
-  # == Test Suite
+  # ## Test Suite
   #
   # As more and more unit tests accumulate for a given project, it
   # becomes a real drag running them one at a time, and it also
@@ -238,7 +238,7 @@ module Test # :nodoc:
   # the dynamic suite using the console TestRunner.
   #
   #
-  # == Configuration file
+  # ## Configuration file
   #
   # Test::Unit reads 'test-unit.yml' in the current working
   # directory as Test::Unit's configuration file. It can
@@ -300,7 +300,7 @@ module Test # :nodoc:
   #         name: green
   #         bold: true
   #
-  # == Questions?
+  # ## Questions?
   #
   # I'd really like to get feedback from all levels of Ruby
   # practitioners about typos, grammatical errors, unclear statements,

--- a/lib/test/unit.rb
+++ b/lib/test/unit.rb
@@ -208,8 +208,8 @@ module Test # :nodoc:
   # runner simply set default test runner ID to
   # Test::Unit::AutoRunner:
   #
-  #    require 'test/unit'
-  #    Test::Unit::AutoRunner.default_runner = "gtk2"
+  #     require 'test/unit'
+  #     Test::Unit::AutoRunner.default_runner = "gtk2"
   #
   # ## Test Suite
   #
@@ -228,10 +228,10 @@ module Test # :nodoc:
   # 'test/unit'. What does this mean? It means you could
   # write the above test case like this instead:
   #
-  #  require 'test/unit'
-  #  require 'test_myfirsttests'
-  #  require 'test_moretestsbyme'
-  #  require 'test_anothersetoftests'
+  #     require 'test/unit'
+  #     require 'test_myfirsttests'
+  #     require 'test_moretestsbyme'
+  #     require 'test_anothersetoftests'
   #
   # Test::Unit is smart enough to find all the test cases existing in
   # the ObjectSpace and wrap them up into a suite for you. It then runs
@@ -254,29 +254,29 @@ module Test # :nodoc:
   #
   # Here are sample color scheme definitions:
   #
-  #   color_schemes:
-  #     inverted:
-  #       success:
-  #         name: red
-  #         bold: true
-  #       failure:
-  #         name: green
-  #         bold: true
-  #     other_scheme:
-  #       ...
+  #     color_schemes:
+  #       inverted:
+  #         success:
+  #           name: red
+  #           bold: true
+  #         failure:
+  #           name: green
+  #           bold: true
+  #       other_scheme:
+  #         ...
   #
   # Here are the syntax of color scheme definitions:
   #
-  #  color_schemes:
-  #    SCHEME_NAME:
-  #      EVENT_NAME:
-  #        name: COLOR_NAME
-  #        intensity: BOOLEAN
-  #        bold: BOOLEAN
-  #        italic: BOOLEAN
-  #        underline: BOOLEAN
-  #      ...
-  #    ...
+  #     color_schemes:
+  #       SCHEME_NAME:
+  #         EVENT_NAME:
+  #           name: COLOR_NAME
+  #           intensity: BOOLEAN
+  #           bold: BOOLEAN
+  #           italic: BOOLEAN
+  #           underline: BOOLEAN
+  #         ...
+  #       ...
   #
   # SCHEME_NAME
   # : the name of the color scheme
@@ -293,17 +293,17 @@ module Test # :nodoc:
   # You can use the above 'inverted' color scheme with the
   # following configuration:
   #
-  #   runner: console
-  #   console_options:
-  #     color_scheme: inverted
-  #   color_schemes:
-  #     inverted:
-  #       success:
-  #         name: red
-  #         bold: true
-  #       failure:
-  #         name: green
-  #         bold: true
+  #     runner: console
+  #     console_options:
+  #       color_scheme: inverted
+  #     color_schemes:
+  #       inverted:
+  #         success:
+  #           name: red
+  #           bold: true
+  #         failure:
+  #           name: green
+  #           bold: true
   #
   # ## Questions?
   #
@@ -336,51 +336,53 @@ module Test # :nodoc:
       # To register multiple hooks, call this method multiple times.
       #
       # Here is an example test case:
-      #   Test::Unit.at_start do
-      #     # ...
-      #   end
       #
-      #   class TestMyClass1 < Test::Unit::TestCase
-      #     class << self
-      #       def startup
+      #     Test::Unit.at_start do
+      #       # ...
+      #     end
+      #
+      #     class TestMyClass1 < Test::Unit::TestCase
+      #       class << self
+      #         def startup
+      #           # ...
+      #         end
+      #       end
+      #
+      #       def setup
+      #         # ...
+      #       end
+      #
+      #       def test_my_class1
+      #         # ...
+      #       end
+      #
+      #       def test_my_class2
       #         # ...
       #       end
       #     end
       #
-      #     def setup
-      #       # ...
-      #     end
+      #     class TestMyClass2 < Test::Unit::TestCase
+      #       class << self
+      #         def startup
+      #           # ...
+      #         end
+      #       end
       #
-      #     def test_my_class1
-      #       # ...
-      #     end
+      #       def setup
+      #         # ...
+      #       end
       #
-      #     def test_my_class2
-      #       # ...
-      #     end
-      #   end
+      #       def test_my_class1
+      #         # ...
+      #       end
       #
-      #   class TestMyClass2 < Test::Unit::TestCase
-      #     class << self
-      #       def startup
+      #       def test_my_class2
       #         # ...
       #       end
       #     end
-      #
-      #     def setup
-      #       # ...
-      #     end
-      #
-      #     def test_my_class1
-      #       # ...
-      #     end
-      #
-      #     def test_my_class2
-      #       # ...
-      #     end
-      #   end
       #
       # Here is a call order:
+      #
       # * at_start
       # * TestMyClass1.startup
       # * TestMyClass1#setup
@@ -420,51 +422,53 @@ module Test # :nodoc:
       # To register multiple hooks, call this method multiple times.
       #
       # Here is an example test case:
-      #   Test::Unit.at_exit do
-      #     # ...
-      #   end
       #
-      #   class TestMyClass1 < Test::Unit::TestCase
-      #     class << self
-      #       def shutdown
+      #     Test::Unit.at_exit do
+      #       # ...
+      #     end
+      #
+      #     class TestMyClass1 < Test::Unit::TestCase
+      #       class << self
+      #         def shutdown
+      #           # ...
+      #         end
+      #       end
+      #
+      #       def teardown
+      #         # ...
+      #       end
+      #
+      #       def test_my_class1
+      #         # ...
+      #       end
+      #
+      #       def test_my_class2
       #         # ...
       #       end
       #     end
       #
-      #     def teardown
-      #       # ...
-      #     end
+      #     class TestMyClass2 < Test::Unit::TestCase
+      #       class << self
+      #         def shutdown
+      #           # ...
+      #         end
+      #       end
       #
-      #     def test_my_class1
-      #       # ...
-      #     end
+      #       def teardown
+      #         # ...
+      #       end
       #
-      #     def test_my_class2
-      #       # ...
-      #     end
-      #   end
+      #       def test_my_class1
+      #         # ...
+      #       end
       #
-      #   class TestMyClass2 < Test::Unit::TestCase
-      #     class << self
-      #       def shutdown
+      #       def test_my_class2
       #         # ...
       #       end
       #     end
-      #
-      #     def teardown
-      #       # ...
-      #     end
-      #
-      #     def test_my_class1
-      #       # ...
-      #     end
-      #
-      #     def test_my_class2
-      #       # ...
-      #     end
-      #   end
       #
       # Here is a call order:
+      #
       # * TestMyClass1#test_my_class1
       # * TestMyClass1#teardown
       # * TestMyClass1#test_my_class2

--- a/lib/test/unit/assertions.rb
+++ b/lib/test/unit/assertions.rb
@@ -171,7 +171,7 @@ module Test
         end
       end
 
-      # Asserts that +object+ is false or nil.
+      # Asserts that `object` is false or nil.
       #
       # @note Just for minitest compatibility. :<
       #
@@ -213,7 +213,7 @@ module Test
       end
 
       ##
-      # Passes if +expected+ == +actual+.
+      # Passes if `expected` == `actual`.
       #
       # Note that the ordering of arguments is important, since a helpful
       # error message is generated when this one fails that tells you the
@@ -314,7 +314,7 @@ EOT
 
 
       ##
-      # Passes if +object+.instance_of?(+klass+). When +klass+ is
+      # Passes if `object`.instance_of?(`klass`). When `klass` is
       # an array of classes, it passes if any class
       # satisfies +object.instance_of?(class).
       #
@@ -348,8 +348,8 @@ EOT
       end
 
       ##
-      # Passes if +object+.instance_of?(+klass+) does not hold.
-      # When +klass+ is an array of classes, it passes if no class
+      # Passes if `object`.instance_of?(`klass`) does not hold.
+      # When `klass` is an array of classes, it passes if no class
       # satisfies +object.instance_of?(class).
       #
       # @example
@@ -389,7 +389,7 @@ EOT
       alias_method :refute_instance_of, :assert_not_instance_of
 
       ##
-      # Passes if +object+ is nil.
+      # Passes if `object` is nil.
       #
       # @example
       #   assert_nil [1, 2].uniq!
@@ -401,7 +401,7 @@ EOT
       end
 
       ##
-      # Passes if +object+.kind_of?(+klass+). When +klass+ is
+      # Passes if `object`.kind_of?(`klass`). When `klass` is
       # an array of classes or modules, it passes if any
       # class or module satisfies +object.kind_of?(class_or_module).
       #
@@ -437,8 +437,8 @@ EOT
       end
 
       ##
-      # Passes if +object+.kind_of?(+klass+) does not hold.
-      # When +klass+ is an array of classes or modules, it passes only if all
+      # Passes if `object`.kind_of?(`klass`) does not hold.
+      # When `klass` is an array of classes or modules, it passes only if all
       # classes (and modules) do not satisfy +object.kind_of?(class_or_module).
       #
       # @example
@@ -478,7 +478,7 @@ EOT
       alias_method :refute_kind_of, :assert_not_kind_of
 
       ##
-      # Passes if +object+ .respond_to? +method+
+      # Passes if `object` .respond_to? `method`
       #
       # @example
       #   assert_respond_to 'bugbear', :slice
@@ -500,7 +500,7 @@ EOT
       end
 
       ##
-      # Passes if +object+ does not .respond_to? +method+.
+      # Passes if `object` does not .respond_to? `method`.
       #
       # @example
       #   assert_not_respond_to('bugbear', :nonexistence) # -> pass
@@ -528,7 +528,7 @@ EOT
       alias_method :refute_respond_to, :assert_not_respond_to
 
       ##
-      # Passes if +pattern+ =~ +string+.
+      # Passes if `pattern` =~ `string`.
       #
       # @example
       #   assert_match(/\d+/, 'five, 6, seven')
@@ -548,7 +548,7 @@ EOT
       end
 
       ##
-      # Passes if +actual+ .equal? +expected+ (i.e. they are the same
+      # Passes if `actual` .equal? `expected` (i.e. they are the same
       # instance).
       #
       # @example
@@ -565,7 +565,7 @@ EOT
       end
 
       ##
-      # Compares the +object1+ with +object2+ using +operator+.
+      # Compares the `object1` with `object2` using `operator`.
       #
       # Passes if object1.__send__(operator, object2) is true.
       #
@@ -585,7 +585,7 @@ EOT
       end
 
       ##
-      # Compares the +object1+ with +object2+ using +operator+.
+      # Compares the `object1` with `object2` using `operator`.
       #
       # Passes if object1.__send__(operator, object2) is not true.
       #
@@ -652,7 +652,7 @@ EOT
       end
 
       ##
-      # Passes if ! +actual+ .equal? +expected+
+      # Passes if ! `actual` .equal? `expected`
       #
       # @example
       #   assert_not_same Object.new, Object.new
@@ -672,7 +672,7 @@ EOT
       alias_method :refute_same, :assert_not_same
 
       ##
-      # Passes if +expected+ != +actual+
+      # Passes if `expected` != `actual`
       #
       # @example
       #   assert_not_equal 'some string', 5
@@ -689,7 +689,7 @@ EOT
       alias_method :refute_equal, :assert_not_equal
 
       ##
-      # Passes if ! +object+ .nil?
+      # Passes if ! `object` .nil?
       #
       # @example
       #   assert_not_nil '1 two 3'.sub!(/two/, '2')
@@ -706,7 +706,7 @@ EOT
       alias_method :refute_nil, :assert_not_nil
 
       ##
-      # Passes if +regexp+ !~ +string+
+      # Passes if `regexp` !~ `string`
       #
       # @example
       #   assert_not_match(/two/, 'one 2 three')   # -> pass
@@ -731,7 +731,7 @@ EOT
       ##
       # Deprecated. Use #assert_not_match instead.
       #
-      # Passes if +regexp+ !~ +string+
+      # Passes if `regexp` !~ `string`
       #
       # @example
       #   assert_no_match(/two/, 'one 2 three')   # -> pass
@@ -789,7 +789,7 @@ EOT
       end
 
       ##
-      # Passes if the block throws +expected_object+
+      # Passes if the block throws `expected_object`
       #
       # @example
       #   assert_throw(:done) do
@@ -860,8 +860,8 @@ EOT
       end
 
       ##
-      # Passes if +expected_float+ and +actual_float+ are equal
-      # within +delta+ tolerance.
+      # Passes if `expected_float` and `actual_float` are equal
+      # within `delta` tolerance.
       #
       # @example
       #   assert_in_delta 0.05, (50000.0 / 10**6), 0.00001
@@ -881,8 +881,8 @@ EOT
       end
 
       ##
-      # Passes if +expected_float+ and +actual_float+ are
-      # not equal within +delta+ tolerance.
+      # Passes if `expected_float` and `actual_float` are
+      # not equal within `delta` tolerance.
       #
       # @example
       #   assert_not_in_delta(0.05, (50000.0 / 10**6), 0.00002) # -> pass
@@ -981,8 +981,8 @@ EOT
 
       public
       ##
-      # Passes if +expected_float+ and +actual_float+ are equal
-      # within +epsilon+ relative error of +expected_float+.
+      # Passes if `expected_float` and `actual_float` are equal
+      # within `epsilon` relative error of `expected_float`.
       #
       # @example
       #   assert_in_epsilon(10000.0, 9900.0, 0.1) # -> pass
@@ -1011,9 +1011,9 @@ EOT
       end
 
       ##
-      # Passes if +expected_float+ and +actual_float+ are
-      # not equal within +epsilon+ relative error of
-      # +expected_float+.
+      # Passes if `expected_float` and `actual_float` are
+      # not equal within `epsilon` relative error of
+      # `expected_float`.
       #
       # @example
       #   assert_not_in_epsilon(10000.0, 9900.0, 0.1) # -> fail
@@ -1121,7 +1121,7 @@ EOT
       ##
       # Passes if the method send returns a true value.
       #
-      # +send_array+ is composed of:
+      # `send_array` is composed of:
       # * A receiver
       # * A method
       # * Arguments to the method
@@ -1161,7 +1161,7 @@ EOT
       ##
       # Passes if the method send doesn't return a true value.
       #
-      # +send_array+ is composed of:
+      # `send_array` is composed of:
       # * A receiver
       # * A method
       # * Arguments to the method
@@ -1199,7 +1199,7 @@ EOT
       end
 
       ##
-      # Passes if +actual+ is a boolean value.
+      # Passes if `actual` is a boolean value.
       #
       # @example
       #   assert_boolean(true) # -> pass
@@ -1215,7 +1215,7 @@ EOT
       end
 
       ##
-      # Passes if +actual+ is true.
+      # Passes if `actual` is true.
       #
       # @example
       #   assert_true(true)  # -> pass
@@ -1231,7 +1231,7 @@ EOT
       end
 
       ##
-      # Passes if +actual+ is false.
+      # Passes if `actual` is false.
       #
       # @example
       #   assert_false(false)  # -> pass
@@ -1247,8 +1247,8 @@ EOT
       end
 
       ##
-      # Passes if expression "+expected+ +operator+
-      # +actual+" is true.
+      # Passes if expression "`expected` `operator`
+      # `actual`" is true.
       #
       # @example
       #   assert_compare(1, "<", 10)  # -> pass
@@ -1303,7 +1303,7 @@ EOT
 
       ##
       # Passes if an exception is raised in block and its
-      # message is +expected+.
+      # message is `expected`.
       #
       # @example
       #   assert_raise_message("exception") {raise "exception"}  # -> pass
@@ -1343,7 +1343,7 @@ EOT
       end
 
       ##
-      # Passes if +object+.const_defined?(+constant_name+)
+      # Passes if `object`.const_defined?(`constant_name`)
       #
       # @example
       #   assert_const_defined(Test, :Unit)          # -> pass
@@ -1360,7 +1360,7 @@ EOT
       end
 
       ##
-      # Passes if !+object+.const_defined?(+constant_name+)
+      # Passes if !`object`.const_defined?(`constant_name`)
       #
       # @example
       #   assert_not_const_defined(Object, :Nonexistent) # -> pass
@@ -1377,7 +1377,7 @@ EOT
       end
 
       ##
-      # Passes if +object+.+predicate+ is _true_.
+      # Passes if `object`.`predicate` is _true_.
       #
       # @example
       #   assert_predicate([], :empty?)  # -> pass
@@ -1399,7 +1399,7 @@ EOT
       end
 
       ##
-      # Passes if +object+.+predicate+ is not _true_.
+      # Passes if `object`.`predicate` is not _true_.
       #
       # @example
       #   assert_not_predicate([1], :empty?) # -> pass
@@ -1426,8 +1426,8 @@ EOT
       alias_method :refute_predicate, :assert_not_predicate
 
       ##
-      # Passes if +object+#+alias_name+ is an alias method of
-      # +object+#+original_name+.
+      # Passes if `object`#`alias_name` is an alias method of
+      # `object`#`original_name`.
       #
       # @example
       #   assert_alias_method([], :length, :size)  # -> pass
@@ -1474,7 +1474,7 @@ EOT
       end
 
       ##
-      # Passes if +path+ exists.
+      # Passes if `path` exists.
       #
       # @example
       #   assert_path_exist("/tmp")          # -> pass
@@ -1492,7 +1492,7 @@ EOT
       end
 
       ##
-      # Passes if +path+ doesn't exist.
+      # Passes if `path` doesn't exist.
       #
       # @example
       #   assert_path_not_exist("/nonexistent")  # -> pass
@@ -1510,7 +1510,7 @@ EOT
       end
 
       ##
-      # Passes if +collection+ includes +object+.
+      # Passes if `collection` includes `object`.
       #
       # @example
       #   assert_include([1, 10], 1)            # -> pass
@@ -1537,7 +1537,7 @@ EOT
       alias_method :assert_includes, :assert_include
 
       ##
-      # Passes if +collection+ doesn't include +object+.
+      # Passes if `collection` doesn't include `object`.
       #
       # @example
       #   assert_not_include([1, 10], 5)            # -> pass
@@ -1569,7 +1569,7 @@ EOT
       alias_method :refute_includes, :assert_not_include
 
       ##
-      # Passes if +object+ is empty.
+      # Passes if `object` is empty.
       #
       # @example
       #   assert_empty("")                       # -> pass
@@ -1592,7 +1592,7 @@ EOT
       end
 
       ##
-      # Passes if +object+ is not empty.
+      # Passes if `object` is not empty.
       #
       # @example
       #   assert_not_empty(" ")                      # -> pass
@@ -1620,8 +1620,8 @@ EOT
       alias_method :refute_empty, :assert_not_empty
 
       ##
-      # Builds a failure message.  +user_message+ is added before the
-      # +template+ and +arguments+ replaces the '?'s positionally in
+      # Builds a failure message.  `user_message` is added before the
+      # `template` and `arguments` replaces the '?'s positionally in
       # the template.
       def build_message(user_message, template=nil, *arguments)
         template &&= template.chomp

--- a/lib/test/unit/data.rb
+++ b/lib/test/unit/data.rb
@@ -187,7 +187,7 @@ module Test
         #
         # @param [String] file_name full path to test data file.
         #   File format is automatically detected from filename extension.
-        # @raise [ArgumentError] if +file_name+ is not supported file format.
+        # @raise [ArgumentError] if `file_name` is not supported file format.
         # @see Loader#load
         #
         # @example Load data from CSV file
@@ -211,7 +211,7 @@ module Test
           #
           # @param [String] file_name full path to test data file.
           #   File format is automatically detected from filename extension.
-          # @raise [ArgumentError] if +file_name+ is not supported file format.
+          # @raise [ArgumentError] if `file_name` is not supported file format.
           # @see #load_csv
           # @see #load_tsv
           # @api private

--- a/lib/test/unit/notification.rb
+++ b/lib/test/unit/notification.rb
@@ -65,15 +65,17 @@ module Test
       # Notify some information.
       #
       # Example:
-      #   def test_notification
-      #     notify("I'm here!")
-      #     # Reached here
-      #     notify("Special!") if special_case?
-      #     # Reached here too
-      #   end
+      #
+      #     def test_notification
+      #       notify("I'm here!")
+      #       # Reached here
+      #       notify("Special!") if special_case?
+      #       # Reached here too
+      #     end
       #
       # options:
-      #   :backtrace override backtrace.
+      #
+      #     :backtrace override backtrace.
       def notify(message, options={}, &block)
         backtrace = filter_backtrace(options[:backtrace] || caller)
         notification = Notification.new(name, backtrace, message,

--- a/lib/test/unit/omission.rb
+++ b/lib/test/unit/omission.rb
@@ -65,17 +65,18 @@ module Test
       # Omit the test or part of the test.
       #
       # Example:
-      #   def test_omission
-      #     omit
-      #     # Not reached here
-      #   end
       #
-      #   def test_omission_with_here
-      #     omit do
-      #       # Not ran here
+      #     def test_omission
+      #       omit
+      #       # Not reached here
       #     end
-      #     # Reached here
-      #   end
+      #
+      #     def test_omission_with_here
+      #       omit do
+      #         # Not ran here
+      #       end
+      #       # Reached here
+      #     end
       def omit(message=nil, &block)
         message ||= "omitted."
         if block_given?
@@ -91,20 +92,21 @@ module Test
       # true.
       #
       # Example:
-      #   def test_omission
-      #     omit_if("".empty?)
-      #     # Not reached here
-      #   end
       #
-      #   def test_omission_with_here
-      #     omit_if(true) do
-      #       # Not ran here
+      #     def test_omission
+      #       omit_if("".empty?)
+      #       # Not reached here
       #     end
-      #     omit_if(false) do
-      #       # Reached here
+      #
+      #     def test_omission_with_here
+      #       omit_if(true) do
+      #         # Not ran here
+      #       end
+      #       omit_if(false) do
+      #         # Reached here
+      #       end
+      #       # Reached here too
       #     end
-      #     # Reached here too
-      #   end
       def omit_if(condition, *args, &block)
         if condition
           omit(*args, &block)
@@ -117,20 +119,21 @@ module Test
       # not true.
       #
       # Example:
-      #   def test_omission
-      #     omit_unless("string".empty?)
-      #     # Not reached here
-      #   end
       #
-      #   def test_omission_with_here
-      #     omit_unless(true) do
-      #       # Reached here
+      #     def test_omission
+      #       omit_unless("string".empty?)
+      #       # Not reached here
       #     end
-      #     omit_unless(false) do
-      #       # Not ran here
+      #
+      #     def test_omission_with_here
+      #       omit_unless(true) do
+      #         # Reached here
+      #       end
+      #       omit_unless(false) do
+      #         # Not ran here
+      #       end
+      #       # Reached here too
       #     end
-      #     # Reached here too
-      #   end
       def omit_unless(condition, *args, &block)
         if condition
           block.call if block

--- a/lib/test/unit/pending.rb
+++ b/lib/test/unit/pending.rb
@@ -65,19 +65,20 @@ module Test
       # Marks the test or part of the test is pending.
       #
       # Example:
-      #   def test_pending
-      #     pend
-      #     # Not reached here
-      #   end
       #
-      #   def test_pending_with_here
-      #     pend do
-      #       # Ran here
-      #       # Fails if the block doesn't raise any error.
-      #       # Because it means the block is passed unexpectedly.
+      #     def test_pending
+      #       pend
+      #       # Not reached here
       #     end
-      #     # Reached here
-      #   end
+      #
+      #     def test_pending_with_here
+      #       pend do
+      #         # Ran here
+      #         # Fails if the block doesn't raise any error.
+      #         # Because it means the block is passed unexpectedly.
+      #       end
+      #       # Reached here
+      #     end
       def pend(message=nil, &block)
         message ||= "pended."
         if block_given?

--- a/lib/test/unit/testcase.rb
+++ b/lib/test/unit/testcase.rb
@@ -269,12 +269,15 @@ module Test
         # Sets the current test order.
         #
         # Here are the available _order_:
-        # [:alphabetic]
-        #   Default. Tests are sorted in alphabetic order.
-        # [:random]
-        #   Tests are sorted in random order.
-        # [:defined]
-        #   Tests are sorted in defined order.
+        #
+        # :alphabetic
+        # : Default. Tests are sorted in alphabetic order.
+        #
+        # :random
+        # : Tests are sorted in random order.
+        #
+        # :defined
+        # : Tests are sorted in defined order.
         def test_order=(order)
           @@test_orders[self] = order
         end

--- a/lib/test/unit/testcase.rb
+++ b/lib/test/unit/testcase.rb
@@ -186,27 +186,29 @@ module Test
         # scope.
         #
         # Here is an example test case:
-        #   class TestMyClass < Test::Unit::TestCase
-        #     class << self
-        #       def startup
+        #
+        #     class TestMyClass < Test::Unit::TestCase
+        #       class << self
+        #         def startup
+        #           ...
+        #         end
+        #       end
+        #
+        #       def setup
+        #         ...
+        #       end
+        #
+        #       def test_my_class1
+        #         ...
+        #       end
+        #
+        #       def test_my_class2
         #         ...
         #       end
         #     end
         #
-        #     def setup
-        #       ...
-        #     end
-        #
-        #     def test_my_class1
-        #       ...
-        #     end
-        #
-        #     def test_my_class2
-        #       ...
-        #     end
-        #   end
-        #
         # Here is a call order:
+        #
         # * startup
         # * setup
         # * test_my_class1 (or test_my_class2)
@@ -222,27 +224,29 @@ module Test
         # down fixture information used in test case scope.
         #
         # Here is an example test case:
-        #   class TestMyClass < Test::Unit::TestCase
-        #     class << self
-        #       def shutdown
+        #
+        #     class TestMyClass < Test::Unit::TestCase
+        #       class << self
+        #         def shutdown
+        #           ...
+        #         end
+        #       end
+        #
+        #       def teardown
+        #         ...
+        #       end
+        #
+        #       def test_my_class1
+        #         ...
+        #       end
+        #
+        #       def test_my_class2
         #         ...
         #       end
         #     end
         #
-        #     def teardown
-        #       ...
-        #     end
-        #
-        #     def test_my_class1
-        #       ...
-        #     end
-        #
-        #     def test_my_class2
-        #       ...
-        #     end
-        #   end
-        #
         # Here is a call order:
+        #
         # * test_my_class1 (or test_my_class2)
         # * teardown
         # * test_my_class2 (or test_my_class1)
@@ -288,22 +292,22 @@ module Test
         # In declarative syntax usage, the following two
         # test definitions are the almost same:
         #
-        #   description "register user"
-        #   def test_register_user
-        #     ...
-        #   end
+        #     description "register user"
+        #     def test_register_user
+        #       ...
+        #     end
         #
-        #   test "register user" do
-        #     ...
-        #   end
+        #     test "register user" do
+        #       ...
+        #     end
         #
         # In test method mark usage, the "my_test_method" is
         # treated as a test method:
         #
-        #   test
-        #   def my_test_method
-        #     assert_equal("call me", ...)
-        #   end
+        #     test
+        #     def my_test_method
+        #       assert_equal("call me", ...)
+        #     end
         def test(*test_description_or_targets, &block)
           if block_given?
             test_description = test_description_or_targets.first
@@ -337,10 +341,10 @@ module Test
         # normal user" description with "test_register"
         # test.
         #
-        #   description "register a normal user"
-        #   def test_register
-        #     ...
-        #   end
+        #     description "register a normal user"
+        #     def test_register
+        #       ...
+        #     end
         def description(value, target=nil)
           targets = [target].compact
           attribute(:description, value, {}, *targets)
@@ -352,20 +356,22 @@ module Test
         # the same in meaning:
         #
         # Standard:
-        #   class TestParent < Test::Unit::TestCase
-        #     class TestChild < self
-        #       def test_in_child
+        #
+        #     class TestParent < Test::Unit::TestCase
+        #       class TestChild < self
+        #         def test_in_child
+        #         end
         #       end
         #     end
-        #   end
         #
         # Syntax sugar:
-        #   class TestParent < Test::Unit::TestCase
-        #     sub_test_case("TestChild") do
-        #       def test_in_child
+        #
+        #     class TestParent < Test::Unit::TestCase
+        #       sub_test_case("TestChild") do
+        #         def test_in_child
+        #         end
         #       end
         #     end
-        #   end
         #
         # The difference of them are the following:
         #
@@ -562,35 +568,37 @@ module Test
       #
       # You can add additional setup tasks by the following
       # code:
-      #   class TestMyClass < Test::Unit::TestCase
-      #     def setup
-      #       ...
-      #     end
       #
-      #     setup
-      #     def my_setup1
-      #       ...
-      #     end
+      #     class TestMyClass < Test::Unit::TestCase
+      #       def setup
+      #         ...
+      #       end
       #
-      #     setup do
-      #       ... # setup callback1
-      #     end
+      #       setup
+      #       def my_setup1
+      #         ...
+      #       end
       #
-      #     setup
-      #     def my_setup2
-      #       ...
-      #     end
+      #       setup do
+      #         ... # setup callback1
+      #       end
       #
-      #     setup do
-      #       ... # setup callback2
-      #     end
+      #       setup
+      #       def my_setup2
+      #         ...
+      #       end
       #
-      #     def test_my_class
-      #       ...
+      #       setup do
+      #         ... # setup callback2
+      #       end
+      #
+      #       def test_my_class
+      #         ...
+      #       end
       #     end
-      #   end
       #
       # Here is a call order:
+      #
       # * setup
       # * my_setup1
       # * setup callback1
@@ -607,35 +615,37 @@ module Test
       #
       # You can add additional cleanup tasks by the following
       # code:
-      #   class TestMyClass < Test::Unit::TestCase
-      #     def cleanup
-      #       ...
-      #     end
       #
-      #     cleanup
-      #     def my_cleanup1
-      #       ...
-      #     end
+      #     class TestMyClass < Test::Unit::TestCase
+      #       def cleanup
+      #         ...
+      #       end
       #
-      #     cleanup do
-      #       ... # cleanup callback1
-      #     end
+      #       cleanup
+      #       def my_cleanup1
+      #         ...
+      #       end
       #
-      #     cleanup
-      #     def my_cleanup2
-      #       ...
-      #     end
+      #       cleanup do
+      #         ... # cleanup callback1
+      #       end
       #
-      #     cleanup do
-      #       ... # cleanup callback2
-      #     end
+      #       cleanup
+      #       def my_cleanup2
+      #         ...
+      #       end
       #
-      #     def test_my_class
-      #       ...
+      #       cleanup do
+      #         ... # cleanup callback2
+      #       end
+      #
+      #       def test_my_class
+      #         ...
+      #       end
       #     end
-      #   end
       #
       # Here is a call order:
+      #
       # * test_my_class
       # * cleanup callback2
       # * my_cleanup2
@@ -650,35 +660,37 @@ module Test
       #
       # You can add additional teardown tasks by the following
       # code:
-      #   class TestMyClass < Test::Unit::TestCase
-      #     def teardown
-      #       ...
-      #     end
       #
-      #     teardown
-      #     def my_teardown1
-      #       ...
-      #     end
+      #     class TestMyClass < Test::Unit::TestCase
+      #       def teardown
+      #         ...
+      #       end
       #
-      #     teardown do
-      #       ... # teardown callback1
-      #     end
+      #       teardown
+      #       def my_teardown1
+      #         ...
+      #       end
       #
-      #     teardown
-      #     def my_teardown2
-      #       ...
-      #     end
+      #       teardown do
+      #         ... # teardown callback1
+      #       end
       #
-      #     teardown do
-      #       ... # teardown callback2
-      #     end
+      #       teardown
+      #       def my_teardown2
+      #         ...
+      #       end
       #
-      #     def test_my_class
-      #       ...
+      #       teardown do
+      #         ... # teardown callback2
+      #       end
+      #
+      #       def test_my_class
+      #         ...
+      #       end
       #     end
-      #   end
       #
       # Here is a call order:
+      #
       # * test_my_class
       # * teardown callback2
       # * my_teardown2

--- a/lib/test/unit/testcase.rb
+++ b/lib/test/unit/testcase.rb
@@ -257,7 +257,7 @@ module Test
         @@test_orders = {}
 
         # Returns the current test order. This returns
-        # +:alphabetic+ by default.
+        # `:alphabetic` by default.
         def test_order
           ancestors.each do |ancestor|
             order = @@test_orders[ancestor]
@@ -695,13 +695,13 @@ module Test
 
       # Returns a label of test data for the test. If the
       # test isn't associated with any test data, it returns
-      # +nil+.
+      # `nil`.
       def data_label
         @internal_data.test_data_label
       end
 
       # Returns test data for the test. If the test isn't associated
-      # with any test data, it returns +nil+.
+      # with any test data, it returns `nil`.
       def data
         @internal_data.test_data
       end

--- a/lib/test/unit/util/observable.rb
+++ b/lib/test/unit/util/observable.rb
@@ -26,8 +26,8 @@ module Test
         # returned, making it very easy to use the proc
         # itself as the listener_key:
         #
-        #  listener = add_listener("Channel") { ... }
-        #  remove_listener("Channel", listener)
+        #     listener = add_listener("Channel") { ... }
+        #     remove_listener("Channel", listener)
         def add_listener(channel_name, listener_key=NOTHING, &listener) # :yields: value
           unless(block_given?)
             raise ArgumentError.new("No callback was passed as a listener")

--- a/lib/test/unit/util/output.rb
+++ b/lib/test/unit/util/output.rb
@@ -7,10 +7,11 @@ module Test
         # error as string.
         #
         # Example:
-        #   capture_output do
-        #     puts("stdout")
-        #     warn("stderr")
-        #   end # -> ["stdout\n", "stderr\n"]
+        #
+        #     capture_output do
+        #       puts("stdout")
+        #       warn("stderr")
+        #     end # -> ["stdout\n", "stderr\n"]
         def capture_output
           require 'stringio'
 


### PR DESCRIPTION
see #163 

This PR makes following changes. These should improve the look of the reference manual.

* Change markup format of source codes from RDoc to Markdown.
    * Convert "heading level 1": `=` --> `#`
    * Convert "heading level 2": `==` --> `##`
    * Convert "code": `+WORD+` --> <code>\`WORD\`</code>
    * Convert "definition lists".
        * However, "Author", "Copyright" and "License" at the beginning of the source code have not changed.
    * Change indents of "code block".
    * Insert necessary blank lines.
* Change `ja.po`