### PR TITLE
Fix encoding related error on showing code snippet

### DIFF
--- a/lib/test/unit/code-snippet-fetcher.rb
+++ b/lib/test/unit/code-snippet-fetcher.rb
@@ -31,9 +31,11 @@ module Test
           break if first_line.nil?
           encoding = detect_encoding(first_line) || Encoding::UTF_8
           first_line.force_encoding(encoding)
-          file.set_encoding(encoding)
           lines << first_line
-          lines.concat(file.readlines)
+          file.each_line do |line|
+            line.force_encoding(encoding)
+            lines << line
+          end
         end
         lines
       end


### PR DESCRIPTION
Retry https://github.com/test-unit/test-unit/commit/5929a43ee3969b96017f84047487c6ce5cbe05ae

A test fails in my env without this patch (e.g https://github.com/ganmacs/fluent-test-ci/runs/380973150)