### PR TITLE
[ready] Allow name filter to match if class name is present

### DIFF
--- a/lib/test/unit/autorunner.rb
+++ b/lib/test/unit/autorunner.rb
@@ -249,8 +249,8 @@ module Test
                "Use '/PATTERN/' for NAME to use regular expression.") do |name|
             name = (%r{\A/(.*)/\Z} =~ name ? Regexp.new($1) : name)
             @filters << lambda do |test|
-              return true if name === test.method_name
-              return true if name === test.local_name
+              return true if (name === test.method_name) || (name === "#{test.class}##{test.method_name}")
+              return true if (name === test.local_name) || (name === "#{test.class}##{test.local_name}")
               false
             end
           end


### PR DESCRIPTION
Currently, it only matches if the `--name` option contains the method only.
This PR is to allow --name option to contain both method or class#method. Like this:
```
--name="test_method"
--name="TestClass#test_method"
```