### PR TITLE
Docs: update link to ruby-talk mailing list

### DIFF
--- a/lib/test/unit.rb
+++ b/lib/test/unit.rb
@@ -46,11 +46,12 @@ module Test # :nodoc:
   # ## Contact Information
   # 
   # A lot of discussion happens about Ruby in general on the ruby-talk
-  # mailing list (http://www.ruby-lang.org/en/ml.html), and you can ask
-  # any questions you might have there. I monitor the list, as do many
-  # other helpful Rubyists, and you're sure to get a quick answer. Of
-  # course, you're also welcome to email me (Nathaniel Talbott) directly
-  # at mailto:testunit@talbott.ws, and I'll do my best to help you out.
+  # mailing list (https://www.ruby-lang.org/en/community/mailing-lists/),
+  # and you can ask any questions you might have there. I monitor the
+  # list, as do many other helpful Rubyists, and you're sure to get a
+  # quick answer. Of course, you're also welcome to email me (Nathaniel
+  # Talbott) directly at mailto:testunit@talbott.ws, and I'll do my best
+  # to help you out.
   # 
   # 
   # ## Credits


### PR DESCRIPTION
Hello, I found a broken link in the docs. Hope this helps!

I also noticed that this affects a derived file at [`doc/po/ja.po`](https://github.com/test-unit/test-unit/blob/4c0c704334e0243d80555dc4075a15985012496c/doc/po/ja.po#L2405-L2413) which is checked into the source tree instead of being ignored like most of the other generated docs. I did not update this file because it looks like there are several pending updates, but I can update it for this change if desired.

Thank you!