### PR TITLE
Improve TERM color detection support

### DIFF
--- a/lib/test/unit/color-scheme.rb
+++ b/lib/test/unit/color-scheme.rb
@@ -7,17 +7,19 @@ module Test
 
       TERM_256 = /
         [+-]256color|
-        ^(alacritty|
+        \A(
+          alacritty|
           iTerm\s?\d*\.app|
           kitty|
           mintty|
           ms-terminal|
-          nsterm|
           nsterm-build\d+|
+          nsterm|
           terminator|
           terminology(-[0-9.]+)?|
           termite|
-          vscode)$/x
+          vscode
+        )\z/x
 
       class << self
         def default

--- a/lib/test/unit/color-scheme.rb
+++ b/lib/test/unit/color-scheme.rb
@@ -7,7 +7,7 @@ module Test
 
       TERM_256 = /
         [+-]256color|
-        \A(
+        \A(?:
           alacritty|
           iTerm\s?\d*\.app|
           kitty|
@@ -16,7 +16,7 @@ module Test
           nsterm-build\d+|
           nsterm|
           terminator|
-          terminology(-[0-9.]+)?|
+          terminology(?:-[0-9.]+)?|
           termite|
           vscode
         )\z/x

--- a/lib/test/unit/color-scheme.rb
+++ b/lib/test/unit/color-scheme.rb
@@ -5,9 +5,23 @@ module Test
     class ColorScheme
       include Enumerable
 
+      TERM_256 = /
+        [+-]256color|
+        ^(alacritty|
+          iTerm\s?\d*\.app|
+          kitty|
+          mintty|
+          ms-terminal|
+          nsterm|
+          nsterm-build\d+|
+          terminator|
+          terminology(-[0-9.]+)?|
+          termite|
+          vscode)$/x
+
       class << self
         def default
-          if available_colors == 256
+          if available_colors >= 256
             default_for_256_colors
           else
             default_for_8_colors
@@ -140,7 +154,9 @@ module Test
 
         def guess_available_colors_from_term_env
           case ENV["TERM"]
-          when /-256color\z/
+          when /[+-]direct/
+            2**24
+          when TERM_256
             256
           else
             nil

--- a/lib/test/unit/ui/console/testrunner.rb
+++ b/lib/test/unit/ui/console/testrunner.rb
@@ -543,16 +543,17 @@ module Test
           TERM_COLOR_SUPPORT = /
             color|  # explicitly claims color support in the name
             direct| # explicitly claims "direct color" (24 bit) support
-            #{ColorScheme::TERM_256}
-            ^cygwin|
-            ^linux|
-            ^nsterm-bce|
-            ^nsterm-c-|
-            ^putty|
-            ^rxvt|
-            ^screen|
-            ^tmux|
-            ^xterm /x
+            #{ColorScheme::TERM_256}|
+            \Acygwin|
+            \Alinux|
+            \Ansterm-bce|
+            \Ansterm-c-|
+            \Aputty|
+            \Arxvt|
+            \Ascreen|
+            \Atmux|
+            \Axterm
+          /x
 
           def guess_color_availability
             return false unless @output.tty?

--- a/lib/test/unit/ui/console/testrunner.rb
+++ b/lib/test/unit/ui/console/testrunner.rb
@@ -540,13 +540,27 @@ module Test
             color("#{@result.status}-marker")
           end
 
+          TERM_COLOR_SUPPORT = /
+            color|  # explicitly claims color support in the name
+            direct| # explicitly claims "direct color" (24 bit) support
+            #{ColorScheme::TERM_256}
+            ^cygwin|
+            ^linux|
+            ^nsterm-bce|
+            ^nsterm-c-.*|
+            ^putty|
+            ^rxvt|
+            ^screen|
+            ^tmux|
+            ^xterm /x
+
           def guess_color_availability
             return false unless @output.tty?
             return true if windows? and ruby_2_0_or_later?
             case ENV["TERM"]
             when /(?:term|screen)(?:-(?:256)?color)?\z/
               true
-            when /\Arxvt/
+            when TERM_COLOR_SUPPORT
               true
             else
               return true if ENV["EMACS"] == "t"

--- a/lib/test/unit/ui/console/testrunner.rb
+++ b/lib/test/unit/ui/console/testrunner.rb
@@ -547,7 +547,7 @@ module Test
             ^cygwin|
             ^linux|
             ^nsterm-bce|
-            ^nsterm-c-.*|
+            ^nsterm-c-|
             ^putty|
             ^rxvt|
             ^screen|

--- a/test/test-color-scheme.rb
+++ b/test/test-color-scheme.rb
@@ -103,7 +103,7 @@ class TestUnitColorScheme < Test::Unit::TestCase
     }.each do |term, colors|
       data("%20s => %8d" % [term, colors], {term: term, colors: colors})
     end
-    def test_available_colors(data)
+    def test_term_env(data)
       ENV["TERM"] = data[:term]
       assert_equal(data[:colors],
                    Test::Unit::ColorScheme.available_colors,

--- a/test/test-color-scheme.rb
+++ b/test/test-color-scheme.rb
@@ -114,7 +114,7 @@ class TestUnitColorScheme < Test::Unit::TestCase
   class TestDefaultScheme < self
     include CleanEnvironment
 
-    def test_default_scheme_for_direct_color
+    def test_direct_color
       ENV["TERM"] = "xterm-direct"
       assert_equal(Test::Unit::ColorScheme.default_for_256_colors,
                    Test::Unit::ColorScheme.default)

--- a/test/test-color-scheme.rb
+++ b/test/test-color-scheme.rb
@@ -84,7 +84,6 @@ class TestUnitColorScheme < Test::Unit::TestCase
       assert_equal(expected_schema_keys.sort,
                    Test::Unit::ColorScheme.default.to_hash.keys.sort)
     end
-
   end
 
   class TestGuessAvailableColors < self
@@ -121,5 +120,4 @@ class TestUnitColorScheme < Test::Unit::TestCase
                    Test::Unit::ColorScheme.default)
     end
   end
-
 end

--- a/test/test-color-scheme.rb
+++ b/test/test-color-scheme.rb
@@ -45,12 +45,14 @@ class TestUnitColorScheme < Test::Unit::TestCase
     def setup
       @original_term, ENV["TERM"] = ENV["TERM"], nil
       @original_color_term, ENV["COLORTERM"] = ENV["COLORTERM"], nil
+      @original_vte_version, ENV["VTE_VERSION"] = ENV["VTE_VERSION"], nil
       ENV["TERM"] = "xterm"
     end
 
     def teardown
       ENV["TERM"] = @original_term
       ENV["COLORTERM"] = @original_color_term
+      ENV["VTE_VERSION"] = @original_vte_version
     end
 
     def test_default
@@ -78,5 +80,35 @@ class TestUnitColorScheme < Test::Unit::TestCase
       assert_equal(expected_schema_keys.sort,
                    Test::Unit::ColorScheme.default.to_hash.keys.sort)
     end
+
+    def test_available_colors
+      terms = {
+        "rxvt"                 => 8,
+        "xterm-color"          => 8,
+        "alacritty"            => 256,
+        "iTerm.app"            => 256,
+        "screen-256color"      => 256,
+        "screenxterm-256color" => 256,
+        "tmux-256color"        => 256,
+        "vte-256color"         => 256,
+        "vscode-direct"        => 2**24,
+        "vte-direct"           => 2**24,
+        "xterm-direct"         => 2**24,
+      }
+      terms.each do |term, expected_available|
+        ENV["TERM"] = term
+        assert_equal(expected_available,
+                     Test::Unit::ColorScheme.available_colors,
+                     "Incorrect available_colors for TERM=%s" % [term])
+      end
+    end
+
+    def test_default_for_direct_color
+      ENV["TERM"] = "xterm-direct"
+      assert_equal(2**24, Test::Unit::ColorScheme.available_colors)
+      assert_equal(Test::Unit::ColorScheme.default_for_256_colors,
+                   Test::Unit::ColorScheme.default)
+    end
+
   end
 end


### PR DESCRIPTION
Adds better color support detection based on TERM variable.  Ultimately,
it would probably be better if we could delegate to the terminfo DB for
this.  But relying on "color" or "256color" or "direct" is fairly safe.