### PR TITLE
Allow strings in `assert_not_match`

### DIFF
--- a/lib/test/unit/assertions.rb
+++ b/lib/test/unit/assertions.rb
@@ -711,15 +711,18 @@ EOT
       # @example
       #   assert_not_match(/two/, 'one 2 three')   # -> pass
       #   assert_not_match(/three/, 'one 2 three') # -> fail
-      def assert_not_match(regexp, string, message=nil)
+      def assert_not_match(pattern, string, message=nil)
         _wrap_assertion do
-          assert_instance_of(Regexp, regexp,
-                             "<REGEXP> in assert_not_match(<REGEXP>, ...) " +
-                             "should be a Regexp.")
+          pattern = case(pattern)
+            when String
+              Regexp.new(Regexp.escape(pattern))
+            else
+              pattern
+          end
           full_message = build_message(message,
                                        "<?> was expected to not match\n<?>.",
-                                       regexp, string)
-          assert_block(full_message) { regexp !~ string }
+                                       pattern, string)
+          assert_block(full_message) { pattern !~ string }
         end
       end
 

--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -954,12 +954,9 @@ EOM
         end
       end
 
-      def test_assert_not_match_fail_not_regexp
-        check_fail("<REGEXP> in assert_not_match(<REGEXP>, ...) " +
-                    "should be a Regexp.\n" +
-                    "<\"asdf\"> was expected to be instance_of?\n" +
-                    "<Regexp> but was\n" +
-                    "<String>.") do
+      def test_assert_not_match_pass_not_regexp
+        check_fail("</asdf/> was expected to not match\n" +
+                    "<\"asdf\">.") do
           assert_not_match("asdf", "asdf")
         end
       end


### PR DESCRIPTION
This makes the behaviour friendlier, and also consistent with
`assert_match`.