### PR TITLE
Fix tests around `assert_not_respond_to` assertion

### DIFF
--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -1094,7 +1094,7 @@ EOM
         end
       end
 
-      def tset_assert_not_respond_to_fail_existence
+      def test_assert_not_respond_to_fail_existence
         check_fail("message.\n" +
                     "!<:symbol>.respond_to?(:to_s) expected\n" +
                     "(Class: <Symbol>)") do

--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -1090,7 +1090,7 @@ EOM
       def test_assert_not_respond_to_fail_number
         check_fail("<0.15>.kind_of?(Symbol) or\n" +
                     "<0.15>.respond_to?(:to_str) expected") do
-          assert_respond_to("thing", 0.15)
+          assert_not_respond_to("thing", 0.15)
         end
       end
 

--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -1094,14 +1094,6 @@ EOM
         end
       end
 
-      def test_assert_not_respond_to_fail_existence
-        check_fail("message.\n" +
-                    "!<:symbol>.respond_to?(:to_s) expected\n" +
-                    "(Class: <Symbol>)") do
-          assert_respond_to(:symbol, :to_s, "message")
-        end
-      end
-
       def test_assert_send
         object = Object.new
         class << object


### PR DESCRIPTION
This looks added in 8f156ded038e96e4b63e2d4bc7d7c10d57562823

Looks having some issues.

* Named the prefix `tset_`, it is not running in `bundle exec rake`.
* The test case is not correct or outdated, I think.
* It is actually testing `assert_respond_to`  instead of `assert_not_respond_to `