### PR TITLE
Boolean assertions checks `true` and `false` without `actual` definitions

### DIFF
--- a/lib/test/unit/assertions.rb
+++ b/lib/test/unit/assertions.rb
@@ -1267,7 +1267,7 @@ EOT
           assert_block(build_message(message,
                                      "<true> or <false> expected but was\n<?>",
                                      actual)) do
-            [true, false].include?(actual)
+            true == actual || false == actual
           end
         end
       end
@@ -1283,7 +1283,7 @@ EOT
           assert_block(build_message(message,
                                      "<true> expected but was\n<?>",
                                      actual)) do
-            actual == true
+            true == actual
           end
         end
       end
@@ -1299,7 +1299,7 @@ EOT
           assert_block(build_message(message,
                                      "<false> expected but was\n<?>",
                                      actual)) do
-            actual == false
+            false == actual
           end
         end
       end

--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -1175,6 +1175,18 @@ EOM
         check_fail("message.\n<true> or <false> expected but was\n<\"XXX\">") do
           assert_boolean("XXX", "message")
         end
+
+        return_true_class = Class.new do
+          def ==(*args)
+            true
+          end
+        end
+
+        thing = return_true_class.new
+
+        check_fail(%Q{<true> or <false> expected but was\n<#{thing.inspect}>}) {
+          assert_boolean(thing)
+        }
       end
 
       def test_assert_true
@@ -1194,6 +1206,18 @@ EOM
           assert_true(nil, "message")
         end
         assert_equal("message", exception.user_message)
+
+        return_true_class = Class.new do
+          def ==(*args)
+            true
+          end
+        end
+
+        thing = return_true_class.new
+
+        check_fail(%Q{<true> expected but was\n<#{thing.inspect}>}) {
+          assert_true(thing)
+        }
       end
 
       def test_assert_false
@@ -1212,6 +1236,18 @@ EOM
         check_fail("message.\n<false> expected but was\n<:false>") do
           assert_false(:false, "message")
         end
+
+        return_true_class = Class.new do
+          def ==(*args)
+            true
+          end
+        end
+
+        thing = return_true_class.new
+
+        check_fail(%Q{<false> expected but was\n<#{thing.inspect}>}) {
+          assert_false(thing)
+        }
       end
 
       def test_assert_compare

--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -834,6 +834,22 @@ EOM
         }
       end
 
+      def test_assert_equal
+        return_true_class = Class.new do
+          def ==(*args)
+            true
+          end
+        end
+
+        thing = return_true_class.new
+
+        assert_equal(thing, true)
+
+        check_fail(%Q{<true> expected but was\n<#{thing.inspect}>.}) {
+          assert_equal(true, thing)
+        }
+      end
+
       def test_assert_nothing_raised
         check_nothing_fails(:dont_care) {
           assert_nothing_raised {


### PR DESCRIPTION
Hi!, I know this PR makes breaking change of the assertions!

Now `assert_equal(true, something)` and `assert_true(something)` does not make same result.

https://github.com/test-unit/test-unit/blob/7dd387ef811e35e7b53d5200fe89ccea1e070e73/lib/test/unit/assertions.rb#L244

Is this an intentional behavior?

Considering the use-case, I would like to ensure matching `true` and `false`, even if the `actual` having evil `==`.

How do you think? :pray: