### PR TITLE
[RFC] Do not depend `actual.nil?` in `assert_nil`

### DIFF
--- a/lib/test/unit/assertions.rb
+++ b/lib/test/unit/assertions.rb
@@ -462,7 +462,7 @@ EOT
         full_message = build_message(message, <<EOT, object)
 <?> was expected to be nil.
 EOT
-        assert_block(full_message) { object.nil? }
+        assert_block(full_message) { nil == object }
       end
 
       ##
@@ -749,7 +749,7 @@ EOT
       alias_method :refute_equal, :assert_not_equal
 
       ##
-      # Passes if ! `object` .nil?
+      # Passes if `object` is not nil
       #
       # @example
       #   assert_not_nil '1 two 3'.sub!(/two/, '2')
@@ -757,7 +757,7 @@ EOT
         full_message = build_message(message,
                                      "<?> was expected to not be nil.",
                                      object)
-        assert_block(full_message){!object.nil?}
+        assert_block(full_message){ nil != object }
       end
 
       # Just for minitest compatibility. :<

--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -728,6 +728,17 @@ EOM
         check_fail(%Q{failed assert_nil.\n<"string"> was expected to be nil.}) {
           assert_nil("string", "failed assert_nil")
         }
+
+        nil_class = Class.new do
+          def nil?
+            true
+          end
+        end
+
+        thing = nil_class.new
+        check_fail(%Q{<#{thing.inspect}> was expected to be nil.}) {
+          assert_nil(thing)
+        }
       end
 
       def test_assert_not_nil
@@ -735,6 +746,15 @@ EOM
         check_nothing_fails{assert_not_nil(false, "message")}
         check_fail("<nil> was expected to not be nil."){assert_not_nil(nil)}
         check_fail("message.\n<nil> was expected to not be nil.") {assert_not_nil(nil, "message")}
+
+        nil_class = Class.new do
+          def nil?
+            true
+          end
+        end
+
+        thing = nil_class.new
+        assert_not_nil(thing)
       end
 
       def test_assert_kind_of


### PR DESCRIPTION
My motivation is same as #181, but divided the PR because this change would be more controversial.

I know ,`RSpec` depends `nil?` in the `be_nil` matcher too.

https://github.com/rspec/rspec-expectations/blob/43bf64b01f8356979ffbc373b2e81d2ab1389b29/lib/rspec/matchers/built_in/be.rb#L68-L70

But I think `assert_predicate(something, :nil?)` covers the use-case. So `assert_nil(something)` comapre only with `nil` is useful to me.

Or I should write `assert_equal(nil, something)` or adding another assertion?
Current assertions looks not taking keyword arguments. I guess it supports for old rubies. So adding behavior change parameter will not fit...