### PR TITLE
Add `documentation_uri` and `bug_tracker_uri` in gemspec

### DIFF
--- a/test-unit.gemspec
+++ b/test-unit.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata = {
     "source_code_uri" => "https://github.com/test-unit/test-unit",
-    "documentation_uri" => "https://rubydoc.info/github/test-unit/test-unit",
+    "documentation_uri" => "https://test-unit.github.io/test-unit/en/",
     "bug_tracker_uri" => "https://github.com/test-unit/test-unit/issues"
   }
 

--- a/test-unit.gemspec
+++ b/test-unit.gemspec
@@ -31,7 +31,9 @@ Gem::Specification.new do |spec|
   spec.test_files += Dir.glob("test/**/*")
 
   spec.metadata = {
-    "source_code_uri" => "https://github.com/test-unit/test-unit"
+    "source_code_uri" => "https://github.com/test-unit/test-unit",
+    "documentation_uri" => "https://rubydoc.info/github/test-unit/test-unit",
+    "bug_tracker_uri" => "https://github.com/test-unit/test-unit/issues"
   }
 
   spec.add_runtime_dependency("power_assert")


### PR DESCRIPTION
test-unit looks positive to writing signature with YARD.
So how about to reference the URL in https://rubygems.org/gems/test-unit?

Before
---

<img width="175" alt="screen_shot 2021-06-06 17 37 09" src="https://user-images.githubusercontent.com/1180335/120918175-fd0d7b00-c6ed-11eb-880e-3137cf620fa3.png">

After
---

<img width="170" alt="screen_shot 2021-06-06 17 37 41" src="https://user-images.githubusercontent.com/1180335/120918176-fe3ea800-c6ed-11eb-8e6d-75bebdfbf54c.png">

If you negative to depend https://rubydoc.info, I will try another PR as self-hosting YARD with `gh-pages`. Then please tell me!
