### PR TITLE
Update using GitHub Actions branch name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runs-on }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}


### PR DESCRIPTION
https://github.com/actions/checkout/compare/master..main
https://github.com/actions/checkout/compare/master..v2

<img width="997" alt="screen_shot 2021-06-06 20 54 38" src="https://user-images.githubusercontent.com/1180335/120923485-bf1e5000-c709-11eb-9845-9d2fefd2dc21.png">
<img width="1016" alt="screen_shot 2021-06-06 20 56 46" src="https://user-images.githubusercontent.com/1180335/120923487-c04f7d00-c709-11eb-8317-ab201f391cd8.png">

Looks `master` branch is not maintained, I’m guessing they have changed default branch to `main` from `master`.