### PR TITLE
Introduce dependabot to update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
I personally use dependabot config as below in own gems.

```yaml
version: 2
updates:
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "daily"
      time: "08:00"
      timezone: "Asia/Tokyo"
  - package-ecosystem: "bundler"
    directory: "/"
    schedule:
      interval: "daily"
      time: "08:00"
      timezone: "Asia/Tokyo"
    versioning-strategy: increase
```

test-unit does not specify versions of dependencies, so `bundler` config is needless, I think.
But introducing `github-actions` might prevent similar as #187 (Honestly, I don't have confident for the behavior 🙇 )

https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#package-ecosystem

How do you think?