### PR TITLE
Fix description for `assert_block`, it is considering `truthy` not `true`

### DIFF
--- a/lib/test/unit/assertions.rb
+++ b/lib/test/unit/assertions.rb
@@ -43,7 +43,7 @@ module Test
 
       ##
       # The assertion upon which all other assertions are based. Passes if the
-      # block yields true.
+      # block yields not false nor nil.
       #
       # @example
       #   assert_block "Couldn't do the thing" do


### PR DESCRIPTION
Is this correct understanding? https://github.com/test-unit/test-unit/blob/a2106658fe85e79478322e03a33f75977b82c911/lib/test/unit/assertions.rb#L54

The new description is taken from `assert`.

https://github.com/test-unit/test-unit/blob/a2106658fe85e79478322e03a33f75977b82c911/lib/test/unit/assertions.rb#L91