### PR TITLE
Use YARD tag `@deprecated` for `assert_no_match`

### DIFF
--- a/lib/test/unit/assertions.rb
+++ b/lib/test/unit/assertions.rb
@@ -787,7 +787,7 @@ EOT
       alias_method :refute_match, :assert_not_match
 
       ##
-      # Deprecated. Use #assert_not_match instead.
+      # @deprecated Use {#assert_not_match} instead.
       #
       # Passes if `regexp` !~ `string`
       #


### PR DESCRIPTION
Before
---

<img width="484" alt="screen_shot 2021-06-06 22 40 57" src="https://user-images.githubusercontent.com/1180335/120926634-b5e8af80-c718-11eb-9289-dd1b316ef334.png">
<img width="596" alt="screen_shot 2021-06-06 22 41 06" src="https://user-images.githubusercontent.com/1180335/120926635-b719dc80-c718-11eb-9c19-3fa0f4e2db15.png">

After
---

<img width="607" alt="screen_shot 2021-06-06 22 42 41" src="https://user-images.githubusercontent.com/1180335/120926636-b7b27300-c718-11eb-9fe5-76991c0a7154.png">
<img width="700" alt="screen_shot 2021-06-06 22 42 53" src="https://user-images.githubusercontent.com/1180335/120926638-b84b0980-c718-11eb-9a11-2303f60fb221.png">
