### PR TITLE
Use `@deprecated` tag with reference syntax

### DIFF
--- a/lib/test/unit.rb
+++ b/lib/test/unit.rb
@@ -324,14 +324,14 @@ module Test # :nodoc:
       # Set true when Test::Unit has run.  If set to true Test::Unit
       # will not automatically run at exit.
       #
-      # @deprecated Use Test::Unit::AutoRunner.need_auto_run= instead.
+      # @deprecated Use {Test::Unit::AutoRunner.need_auto_run=} instead.
       def run=(have_run)
         AutoRunner.need_auto_run = (not have_run)
       end
 
       # Already tests have run?
       #
-      # @deprecated Use Test::Unit::AutoRunner.need_auto_run? instead.
+      # @deprecated Use {Test::Unit::AutoRunner.need_auto_run?} instead.
       def run?
         not AutoRunner.need_auto_run?
       end


### PR DESCRIPTION
Before
---

<img width="575" alt="screen_shot 2021-06-07 4 02 54" src="https://user-images.githubusercontent.com/1180335/120936944-9f0c8200-c745-11eb-85ff-715bd4d60ae7.png">
<img width="734" alt="screen_shot 2021-06-07 4 03 01" src="https://user-images.githubusercontent.com/1180335/120936945-a0d64580-c745-11eb-9bb8-0ee2bb5fdc73.png">

After
---

<img width="575" alt="screen_shot 2021-06-07 4 04 05" src="https://user-images.githubusercontent.com/1180335/120936947-a16edc00-c745-11eb-924c-2d60d5611fa6.png">
<img width="696" alt="screen_shot 2021-06-07 4 04 12" src="https://user-images.githubusercontent.com/1180335/120936949-a2077280-c745-11eb-88ff-78437b939f2e.png">

The link will work

<img width="627" alt="screen_shot 2021-06-07 4 04 18" src="https://user-images.githubusercontent.com/1180335/120936950-a2a00900-c745-11eb-809b-fa3e5dc64c38.png">
