### PR TITLE
Update status badges on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # test-unit
 
-[![](https://badge.fury.io/rb/test-unit.svg)](http://badge.fury.io/rb/test-unit)
-[![](https://travis-ci.org/test-unit/test-unit.svg?branch=master)](https://travis-ci.org/test-unit/test-unit)
+[![Gem Version](https://badge.fury.io/rb/test-unit.png)](http://badge.fury.io/rb/test-unit)
+[![Build Status for Ruby 2.1+](https://github.com/test-unit/test-unit/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/test-unit/test-unit/actions/workflows/test.yml?query=branch%3Amaster+)
+[![Build Status for Ruby 1.9 and 2.0](https://travis-ci.com/test-unit/test-unit.svg?branch=master)](https://travis-ci.com/test-unit/test-unit)
 
 * http://test-unit.github.io/
 * https://github.com/test-unit/test-unit


### PR DESCRIPTION
Current badges looks bit old 📛 

* Missing GitHub Actions badge. It is preferable rather than Travis-CI because testing on newer rubies.
* https://travis-ci.org/test-unit/test-unit shows old results, they looks have been moved to new URL.

Before
---

<img width="1224" alt="screen_shot 2021-06-07 12 21 51" src="https://user-images.githubusercontent.com/1180335/120955067-87f08300-c78b-11eb-903b-0698f7e1eeab.png">
<img width="1096" alt="screen_shot 2021-06-07 12 21 57" src="https://user-images.githubusercontent.com/1180335/120955072-8a52dd00-c78b-11eb-8e8a-fcae0b2b8eae.png">

After
---

<img width="490" alt="screen_shot 2021-06-07 12 26 47" src="https://user-images.githubusercontent.com/1180335/120955134-abb3c900-c78b-11eb-8fea-15c4f23b81d4.png">
<img width="945" alt="screen_shot 2021-06-07 12 27 21" src="https://user-images.githubusercontent.com/1180335/120955164-bf5f2f80-c78b-11eb-9330-882a5365374b.png">
<img width="909" alt="screen_shot 2021-06-07 12 27 27" src="https://user-images.githubusercontent.com/1180335/120955168-c25a2000-c78b-11eb-8028-6def145fbc07.png">

Note
---

`doc/po/ja.po` looks having same URL, but I did not update in this PR 

