### PR TITLE
Prefer canonical qualified names for classes under Thread

### DIFF
--- a/lib/test/unit/testcase.rb
+++ b/lib/test/unit/testcase.rb
@@ -447,7 +447,7 @@ module Test
         # @private
         @@method_locations = {}
         # @private
-        @@method_location_mutex = Mutex.new
+        @@method_location_mutex = Thread::Mutex.new
 
         # @private
         def method_locations


### PR DESCRIPTION
As `Mutex` has been moved under `Thread` since ruby 2.3, and might be deprecated in future.