### PR TITLE
Fix to set class instance variable `@debug_on_failure`

### DIFF
--- a/lib/test/unit/assertion-failed-error.rb
+++ b/lib/test/unit/assertion-failed-error.rb
@@ -9,8 +9,8 @@ module Test
 
     # Thrown by Test::Unit::Assertions when an assertion fails.
     class AssertionFailedError < StandardError
+      @debug_on_failure = false
       class << self
-        @debug_on_failure = false
         def debug_on_failure=(boolean)
           @debug_on_failure = boolean
         end


### PR DESCRIPTION
Follow https://github.com/test-unit/test-unit/commit/a66061f9236ae16eb8c287cf62bf60dc8d39ae45

Before Ruby 3.0, uninitialized instance variable shows warning as below.

Before
---

```console
$ ruby -v && bundle exec rake 2>&1 | grep 'warning' | fgrep '/lib/' | wc -l
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin20]
175
```

After
---

```console
$ ruby -v && bundle exec rake 2>&1 | grep 'warning' | fgrep '/lib/' | wc -l
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin20]
0
```