### PR TITLE
Restore lazy fileutils require

### DIFF
--- a/lib/test/unit/priority.rb
+++ b/lib/test/unit/priority.rb
@@ -1,5 +1,3 @@
-require "fileutils"
-
 module Test
   module Unit
     module Priority


### PR DESCRIPTION
This is a PR to check CI and to ask whether this require is needed.

In https://github.com/test-unit/test-unit/commit/135f2bfed57c1b30acc3350ef07cc8a0c04bdb6f, these require was moved to the `Test::Unit::Priority.enable` method, because users that don't use this class don't need to use it.

However, in https://github.com/test-unit/test-unit/commit/1eccf3cda5417ccb10047bd69f796eac9bf7c31c it was added back, although I'm not fully sure why.

I open this because requiring `fileutils` is causing some conflicts when testing the `etc` gem (because the `fileutils` version on older rubies used to require `etc`, and that causes conflicts with the `etc` version being tested). See https://github.com/ruby/etc/pull/14.