### PR TITLE
Update the test suite to handle ASCII-8BIT renaming.

### DIFF
--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -394,7 +394,7 @@ EOM
             ascii_8bit_string = utf8_string.dup.force_encoding("ascii-8bit")
             message = <<-EOM.chomp
 <#{utf8_string.inspect}>("UTF-8") expected but was
-<#{ascii_8bit_string.inspect}>("ASCII-8BIT").
+<#{ascii_8bit_string.inspect}>("#{Encoding::ASCII_8BIT.name}").
 EOM
             check_fail(message) do
               assert_equal(utf8_string, ascii_8bit_string)


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/18576
Ref: https://github.com/ruby/ruby/pull/5571

I'd like to rename `ASCII-8BIT` into `BINARY` for Ruby 3.2, and since test-unit's test suite is integrated into Ruby it breaks the build.