### PR TITLE
Support BigDecimal in assert_in_delta and its family

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,7 @@
 source "https://rubygems.org"
 
 gemspec
+
+group :test do
+  gem "bigdecimal", platforms: [:mri]
+end

--- a/lib/test/unit/assertions.rb
+++ b/lib/test/unit/assertions.rb
@@ -1089,22 +1089,52 @@ EOT
       def assert_in_epsilon(expected_float, actual_float, epsilon=0.001,
                             message="")
         _wrap_assertion do
-          _assert_in_epsilon_validate_arguments(expected_float,
-                                                actual_float,
-                                                epsilon)
-          full_message = _assert_in_epsilon_message(expected_float,
-                                                    actual_float,
-                                                    epsilon,
-                                                    message)
-          assert_block(full_message) do
-            normalized_expected_float = expected_float.to_f
-            if normalized_expected_float.zero?
-              delta = epsilon.to_f ** 2
+          begin
+            zero_p = expected_float.zero? rescue expected_float == 0
+            if zero_p
+              delta = epsilon ** 2
             else
-              delta = normalized_expected_float * epsilon.to_f
+              delta = expected_float * epsilon
             end
             delta = delta.abs
-            (normalized_expected_float - actual_float.to_f).abs <= delta
+            pass = (expected_float - actual_float).abs <= delta
+            assert_operator(epsilon, :>=, 0.0, "The epsilon should not be negative")
+            full_message = _assert_in_epsilon_message(expected_float,
+                                                      expected_float,
+                                                      actual_float,
+                                                      actual_float,
+                                                      epsilon,
+                                                      epsilon,
+                                                      delta,
+                                                      message)
+          rescue Test::Unit::AssertionFailedError
+            # for the above assert_operator
+            raise
+          rescue
+            _assert_in_epsilon_validate_arguments(expected_float,
+                                                  actual_float,
+                                                  epsilon)
+            normalized_expected = expected_float.to_f
+            normalized_actual = actual_float.to_f
+            normalized_epsilon = epsilon.to_f
+            if normalized_expected.zero?
+              delta = normalized_epsilon ** 2
+            else
+              delta = normalized_expected * normalized_epsilon
+            end
+            delta = delta.abs
+            full_message = _assert_in_epsilon_message(expected_float,
+                                                      normalized_expected,
+                                                      actual_float,
+                                                      normalized_actual,
+                                                      epsilon,
+                                                      normalized_epsilon,
+                                                      delta,
+                                                      message)
+            pass = (normalized_expected - normalized_actual).abs <= delta
+          end
+          assert_block(full_message) do
+            pass
           end
         end
       end
@@ -1120,18 +1150,43 @@ EOT
       def assert_not_in_epsilon(expected_float, actual_float, epsilon=0.001,
                                 message="")
         _wrap_assertion do
-          _assert_in_epsilon_validate_arguments(expected_float,
-                                                actual_float,
-                                                epsilon)
-          full_message = _assert_in_epsilon_message(expected_float,
-                                                    actual_float,
-                                                    epsilon,
-                                                    message,
-                                                    :negative_assertion => true)
+          begin
+            delta = expected_float * epsilon
+            pass = (expected_float - actual_float).abs > delta
+            assert_operator(epsilon, :>=, 0.0, "The epsilon should not be negative")
+            full_message = _assert_in_epsilon_message(expected_float,
+                                                      expected_float,
+                                                      actual_float,
+                                                      actual_float,
+                                                      epsilon,
+                                                      epsilon,
+                                                      delta,
+                                                      message,
+                                                      :negative_assertion => true)
+          rescue Test::Unit::AssertionFailedError
+            # for the above assert_operator
+            raise
+          rescue
+            _assert_in_epsilon_validate_arguments(expected_float,
+                                                  actual_float,
+                                                  epsilon)
+            normalized_expected = expected_float.to_f
+            normalized_actual = actual_float.to_f
+            normalized_epsilon = epsilon.to_f
+            delta = normalized_expected * normalized_epsilon
+            pass = (normalized_expected - normalized_actual).abs > delta
+            full_message = _assert_in_epsilon_message(expected_float,
+                                                      normalized_expected,
+                                                      actual_float,
+                                                      normalized_actual,
+                                                      epsilon,
+                                                      normalized_epsilon,
+                                                      delta,
+                                                      message,
+                                                      :negative_assertion => true)
+          end
           assert_block(full_message) do
-            normalized_expected_float = expected_float.to_f
-            delta = normalized_expected_float * epsilon.to_f
-            (normalized_expected_float - actual_float.to_f).abs > delta
+            pass
           end
         end
       end
@@ -1158,13 +1213,10 @@ EOT
         assert_operator(epsilon, :>=, 0.0, "The epsilon should not be negative")
       end
 
-      def _assert_in_epsilon_message(expected_float, actual_float, epsilon,
-                                     message, options={})
-        normalized_expected = expected_float.to_f
-        normalized_actual = actual_float.to_f
-        normalized_epsilon = epsilon.to_f
-        delta = normalized_expected * normalized_epsilon
-
+      def _assert_in_epsilon_message(expected_float, normalized_expected,
+                                     actual_float, normalized_actual,
+                                     epsilon, normalized_epsilon,
+                                     delta, message, options={})
         if options[:negative_assertion]
           format = <<-EOT
 <?> -/+ (<?> * <?>)[?] was expected to not include

--- a/test-unit.gemspec
+++ b/test-unit.gemspec
@@ -41,4 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("yard")
   spec.add_development_dependency("kramdown")
   spec.add_development_dependency("packnga")
+  spec.add_development_dependency("bigdecimal")
 end

--- a/test-unit.gemspec
+++ b/test-unit.gemspec
@@ -41,5 +41,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("yard")
   spec.add_development_dependency("kramdown")
   spec.add_development_dependency("packnga")
-  spec.add_development_dependency("bigdecimal")
 end

--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -2358,6 +2358,11 @@ message.
       end
 
       def test_fail_with_float_like_object
+        if RUBY_PLATFORM == "truffleruby"
+          omit("This fails on TruffleRuby; " +
+               "see https://github.com/test-unit/test-unit/pull/218 for details")
+        end
+
         object = Object.new
         def object.to_f
           0.4

--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -1794,6 +1794,131 @@ message.
       end
     end
 
+    class TestAssertInDeltaBigDecimal < Test::Unit::TestCase
+      include AssertionCheckable
+
+      def test_pass
+        check_nothing_fails do
+          assert_in_delta(BigDecimal("1.40000000000000000001"),
+                          BigDecimal("1.40000000000000000001"),
+                          0)
+        end
+      end
+
+      def test_pass_without_delta
+        check_nothing_fails do
+          assert_in_delta(BigDecimal("1.40000000000000000001"),
+                          BigDecimal("1.40000000000000000002"))
+        end
+      end
+
+      def test_pass_with_message
+        check_nothing_fails do
+          assert_in_delta(BigDecimal("1.40000000000000000001"),
+                          BigDecimal("1.50000000000000000001"),
+                          BigDecimal("0.1"),
+                          "message")
+        end
+      end
+
+      def test_pass_float_like_object
+        check_nothing_fails do
+          float_thing = Object.new
+          def float_thing.to_f
+            0.2
+          end
+          assert_in_delta(BigDecimal("0.1"),
+                          float_thing,
+                          BigDecimal("0.1"))
+        end
+      end
+
+      def test_pass_string_expected
+        check_nothing_fails do
+          assert_in_delta("0.5",
+                          BigDecimal("0.4"),
+                          BigDecimal("0.1"))
+        end
+      end
+
+      def test_fail_with_message
+        check_fail("message.\n" +
+                    "<0.50000000000000000001e0> -/+ <0.5e-1> was expected to include\n" +
+                    "<0.40000000000000000001e0>.\n" +
+                    "\n" +
+                    "Relation:\n" +
+                    "<" +
+                    "<0.40000000000000000001e0> < " +
+                    "<0.50000000000000000001e0>-<0.5e-1>[0.45000000000000000001e0] <= " +
+                    "<0.50000000000000000001e0>+<0.5e-1>[0.55000000000000000001e0]" +
+                    ">") do
+          assert_in_delta(BigDecimal("0.50000000000000000001"),
+                          BigDecimal("0.40000000000000000001"),
+                          BigDecimal("0.05"),
+                          "message")
+        end
+      end
+
+      def test_fail_because_not_float_like_object
+        object = Object.new
+        inspected_object = AssertionMessage.convert(object)
+        check_fail("The arguments must respond to to_f; " +
+                    "the first float did not.\n" +
+                    "<#{inspected_object}>.respond_to?(:to_f) expected\n" +
+                    "(Class: <Object>)") do
+          assert_in_delta(object,
+                          BigDecimal("0.4"),
+                          BigDecimal("0.1"))
+        end
+      end
+
+      def test_fail_with_float_like_object
+        object = Object.new
+        def object.to_f
+          0.4
+        end
+        inspected_object = AssertionMessage.convert(object)
+        check_fail("<0.10000000000000000001e0> -/+ <0.1e0> was expected to include\n" +
+                    "<#{object}>.\n" +
+                    "\n" +
+                    "Relation:\n" +
+                    "<" +
+                    "<0.10000000000000000001e0>-<0.1e0>[0.0] <= " +
+                    "<0.10000000000000000001e0>+<0.1e0>[0.2] < " +
+                    "<#{object}>" +
+                    ">") do
+          assert_in_delta(BigDecimal("0.10000000000000000001"),
+                          object,
+                          BigDecimal("0.1"))
+        end
+      end
+
+      def test_fail_because_negaitve_delta
+        check_fail("The delta should not be negative.\n" +
+                   "<-0.1e0> was expected to be\n>=\n<0.0>.") do
+          assert_in_delta(BigDecimal("0.5"),
+                          BigDecimal("0.4"),
+                          BigDecimal("-0.1"),
+                          "message")
+        end
+      end
+
+      def test_fail_without_delta
+        check_fail("<0.140200000000000000001e1> -/+ <0.001> was expected to include\n" +
+                    "<0.140400000000000000001e1>.\n" +
+                    "\n" +
+                    "Relation:\n" +
+                    "<" +
+                    "<0.140200000000000000001e1>-<0.001>[0.140100000000000000001e1] <= " +
+                    "<0.140200000000000000001e1>+<0.001>[0.140300000000000000001e1] < " +
+                    "<0.140400000000000000001e1>" +
+                    ">") do
+          assert_in_delta(BigDecimal("1.40200000000000000001"),
+                          BigDecimal("1.40400000000000000001"))
+        end
+      end
+    end
+
     class TestAssertNotInDelta < Test::Unit::TestCase
       include AssertionCheckable
 
@@ -1889,6 +2014,153 @@ message.
         check_fail("The delta should not be negative.\n" +
                     "<-0.11> was expected to be\n>=\n<0.0>.") do
           assert_not_in_delta(0.5, 0.4, -0.11, "message")
+        end
+      end
+    end
+
+    class TestAssertNotInDeltaBigDecimal < Test::Unit::TestCase
+      include AssertionCheckable
+
+      def test_pass
+        check_nothing_fails do
+          assert_not_in_delta(BigDecimal("1.42000000000000000001"),
+                              BigDecimal("1.42000000000000000002"),
+                              BigDecimal("0.000000000000000000005"))
+        end
+      end
+
+      def test_pass_without_delta
+        check_nothing_fails do
+          assert_not_in_delta(BigDecimal("1.40200000000000000001"),
+                              BigDecimal("1.40400000000000000001"))
+        end
+      end
+
+      def test_pass_with_message
+        check_nothing_fails do
+          assert_not_in_delta(BigDecimal("0.50000000000000000001"),
+                              BigDecimal("0.50000000000000000002"),
+                              BigDecimal("0.000000000000000000009"),
+                              "message")
+        end
+      end
+
+      def test_pass_float_like_object
+        check_nothing_fails do
+          float_thing = Object.new
+          def float_thing.to_f
+            0.2
+          end
+          assert_not_in_delta(BigDecimal("0.10000000000000000001"),
+                              float_thing,
+                              BigDecimal("0.09"))
+        end
+      end
+
+      def test_pass_string_epxected
+        check_nothing_fails do
+          assert_not_in_delta("0.5",
+                              BigDecimal("0.4"),
+                              BigDecimal("0.09"))
+        end
+      end
+
+      def test_fail
+        check_fail("<0.140000000000000000001e1> -/+ <0.5e-19> was expected to not include\n" +
+                    "<0.140000000000000000002e1>.\n" +
+                    "\n" +
+                    "Relation:\n" +
+                    "<" +
+                    "<0.140000000000000000001e1>-<0.5e-19>[0.139999999999999999996e1] <= " +
+                    "<0.140000000000000000002e1> <= " +
+                    "<0.140000000000000000001e1>+<0.5e-19>[0.140000000000000000006e1]" +
+                    ">") do
+          assert_not_in_delta(BigDecimal("1.40000000000000000001"),
+                              BigDecimal("1.40000000000000000002"),
+                              BigDecimal("0.00000000000000000005"))
+        end
+      end
+
+      def test_fail_without_delta
+        check_fail("<0.140200000000000000001e1> -/+ <0.001> was expected to not include\n" +
+                    "<0.140210000000000000001e1>.\n" +
+                    "\n" +
+                    "Relation:\n" +
+                    "<" +
+                    "<0.140200000000000000001e1>-<0.001>" +
+                    "[#{BigDecimal("1.40200000000000000001") - 0.001}] <= " +
+                    "<0.140210000000000000001e1> <= " +
+                    "<0.140200000000000000001e1>+<0.001>" +
+                    "[#{BigDecimal("1.40200000000000000001") + 0.001}]" +
+                    ">") do
+          assert_not_in_delta(BigDecimal("1.40200000000000000001"),
+                              BigDecimal("1.40210000000000000001"))
+        end
+      end
+
+      def test_fail_with_message
+        x = BigDecimal("0.1234567890123456789")
+        y = BigDecimal("0.1234567890123456788")
+        d = BigDecimal("0.0000000000000000005")
+        check_fail("message.\n" +
+                    "<0.50000000000000000001e0> -/+ <0.5e-19> was expected to not include\n" +
+                    "<0.50000000000000000002e0>.\n" +
+                    "\n" +
+                    "Relation:\n" +
+                    "<" +
+                    "<0.50000000000000000001e0>-<0.5e-19>[0.49999999999999999996e0] <= " +
+                    "<0.50000000000000000002e0> <= " +
+                    "<0.50000000000000000001e0>+<0.5e-19>[0.50000000000000000006e0]" +
+                    ">") do
+          assert_not_in_delta(BigDecimal("0.50000000000000000001"),
+                              BigDecimal("0.50000000000000000002"),
+                              BigDecimal("0.00000000000000000005"),
+                              "message")
+        end
+      end
+
+      def test_fail_with_float_like_object
+        x = BigDecimal("0.1")
+        object = Object.new
+        def object.to_f
+          0.4
+        end
+        inspected_object = AssertionMessage.convert(object)
+        check_fail("<0.1e0> -/+ <0.5e0> was expected to not include\n" +
+                    "<#{object}>.\n" +
+                    "\n" +
+                    "Relation:\n" +
+                    "<" +
+                    "<0.1e0>-<0.5e0>[#{0.1 - 0.5}] <= " +
+                    "<#{object}> <= " +
+                    "<0.1e0>+<0.5e0>[#{0.1 + 0.5}]" +
+                    ">") do
+          assert_not_in_delta(BigDecimal("0.1"),
+                              object,
+                              BigDecimal("0.5"))
+        end
+      end
+
+      def test_fail_because_not_float_like_object
+        object = Object.new
+        inspected_object = AssertionMessage.convert(object)
+        check_fail("The arguments must respond to to_f; " +
+                    "the first float did not.\n" +
+                    "<#{inspected_object}>.respond_to?(:to_f) expected\n" +
+                    "(Class: <Object>)") do
+          assert_not_in_delta(object,
+                              BigDecimal("0.4"),
+                              BigDecimal("0.1"))
+        end
+      end
+
+      def test_fail_because_negaitve_delta
+        check_fail("The delta should not be negative.\n" +
+                   "<-5.0e-20> was expected to be\n>=\n<0.0>.") do
+          assert_not_in_delta(BigDecimal("+0.500000000000000000001"),
+                              BigDecimal("+0.500000000000000000002"),
+                              BigDecimal("-0.00000000000000000005"),
+                              "message")
         end
       end
     end

--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -2358,7 +2358,7 @@ message.
       end
 
       def test_fail_with_float_like_object
-        if RUBY_PLATFORM == "truffleruby"
+        if RUBY_ENGINE == "truffleruby"
           omit("This fails on TruffleRuby; " +
                "see https://github.com/test-unit/test-unit/pull/218 for details")
         end

--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -2264,6 +2264,150 @@ message.
       end
     end
 
+    class TestAssertInEpsilonBigDecimal < TestCase
+      include AssertionCheckable
+
+      def test_pass
+        check_nothing_fails do
+          assert_in_epsilon(BigDecimal("1.0e1000"),
+                            BigDecimal("0.9e1000"),
+                            BigDecimal("0.1"))
+        end
+      end
+
+      def test_pass_without_epsilon
+        check_nothing_fails do
+          assert_in_epsilon(BigDecimal("1.0e1000"),
+                            BigDecimal("0.9991e1000"))
+        end
+      end
+
+      def test_pass_with_message
+        check_nothing_fails do
+          assert_in_epsilon(BigDecimal("1.0e1000"),
+                            BigDecimal("0.9e1000"),
+                            BigDecimal("0.1"),
+                            "message")
+        end
+      end
+
+      def test_pass_float_like_object
+        check_nothing_fails do
+          float_thing = Object.new
+          def float_thing.to_f
+            9000.0
+          end
+          assert_in_epsilon(BigDecimal("10000"),
+                            float_thing,
+                            BigDecimal("0.1"))
+        end
+      end
+
+      def test_pass_string_expected
+        check_nothing_fails do
+          assert_in_epsilon("10000",
+                            BigDecimal("9000"),
+                            BigDecimal("0.1"))
+        end
+      end
+
+      def test_pass_zero_expected
+        check_nothing_fails do
+          assert_in_epsilon(BigDecimal("0"),
+                            BigDecimal("1e-1000"))
+        end
+      end
+
+      def test_pass_minus_expected
+        check_nothing_fails do
+          assert_in_epsilon(BigDecimal("-1"),
+                            BigDecimal("-1"))
+        end
+      end
+
+      def test_fail_with_message
+        check_fail("message.\n" +
+                    "<0.1e501> -/+ (<0.1e501> * <0.1e0>)[0.1e500] " +
+                    "was expected to include\n" +
+                    "<0.8999e500>.\n" +
+                    "\n" +
+                    "Relation:\n" +
+                    "<" +
+                    "<0.8999e500> < " +
+                    "<0.1e501>-(<0.1e501>*<0.1e0>)[0.9e500] <= " +
+                    "<0.1e501>+(<0.1e501>*<0.1e0>)[0.11e501]" +
+                    ">") do
+          assert_in_epsilon(BigDecimal("1e500"),
+                            BigDecimal("0.8999e500"),
+                            BigDecimal("0.1"),
+                            "message")
+        end
+      end
+
+      def test_fail_because_not_float_like_object
+        object = Object.new
+        inspected_object = AssertionMessage.convert(object)
+        check_fail("The arguments must respond to to_f; " +
+                    "the first float did not.\n" +
+                    "<#{inspected_object}>.respond_to?(:to_f) expected\n" +
+                    "(Class: <Object>)") do
+          assert_in_epsilon(object,
+                            BigDecimal("0.9e500"),
+                            BigDecimal("0.1"))
+        end
+      end
+
+      def test_fail_with_float_like_object
+        object = Object.new
+        def object.to_f
+          0.4
+        end
+        check_fail("<0.10000000000000000001e0> -/+ (<0.10000000000000000001e0> * <0.1e0>)" +
+                   "[0.010000000000000002] was expected to include\n" +
+                   "<#{object}>.\n" +
+                   "\n" +
+                   "Relation:\n" +
+                   "<" +
+                   "<0.10000000000000000001e0>-(<0.10000000000000000001e0>*<0.1e0>)" +
+                   "[0.09] <= " +
+                   "<0.10000000000000000001e0>+(<0.10000000000000000001e0>*<0.1e0>)" +
+                   "[0.11000000000000001] < " +
+                   "<#{object}>" +
+                   ">"
+                  ) do
+          assert_in_epsilon(BigDecimal("0.10000000000000000001"),
+                            object,
+                            BigDecimal("0.1"))
+        end
+      end
+
+      def test_fail_because_negaitve_epsilon
+        check_fail("The epsilon should not be negative.\n" +
+                    "<-0.1e0> was expected to be\n>=\n<0.0>.") do
+          assert_in_epsilon(BigDecimal("1.0e500"),
+                            BigDecimal("0.9e500"),
+                            BigDecimal("-0.1"),
+                            "message")
+        end
+      end
+
+      def test_fail_without_epsilon
+        check_fail("<0.1e501> -/+ (<0.1e501> * <0.001>)[0.1e498] " +
+                    "was expected to include\n" +
+                    "<0.10011e501>.\n" +
+                    "\n" +
+                    "Relation:\n" +
+                    "<" +
+                    "<0.1e501>-(<0.1e501>*<0.001>)[0.999e500] <= " +
+                    "<0.1e501>+(<0.1e501>*<0.001>)[0.1001e501] < " +
+                    "<0.10011e501>" +
+                    ">") do
+          assert_in_epsilon(BigDecimal("1.0000e500"),
+                            BigDecimal("1.0011e500"))
+        end
+      end
+    end
+
     class TestAssertNotInEpsilon < Test::Unit::TestCase
       include AssertionCheckable
 
@@ -2347,6 +2491,28 @@ message.
         end
       end
 
+      def test_fail_with_float_like_object
+        object = Object.new
+        def object.to_f
+          0.4
+        end
+        check_fail("<0.1e1001> -/+ (<0.1e1001> * <0.1e0>)" +
+                   "[Infinity] was expected to not include\n" +
+                   "<#{object}>.\n" +
+                   "\n" +
+                   "Relation:\n" +
+                   "<" +
+                   "<0.1e1001>-(<0.1e1001>*<0.1e0>)[NaN] <= " +
+                   "<#{object}> <= " +
+                   "<0.1e1001>+(<0.1e1001>*<0.1e0>)[Infinity]" +
+                   ">"
+                  ) do
+          assert_not_in_epsilon(BigDecimal("1e1000"),
+                                object,
+                                BigDecimal("0.1"))
+        end
+      end
+
       def test_fail_because_not_float_like_object
         object = Object.new
         inspected_object = AssertionMessage.convert(object)
@@ -2362,6 +2528,129 @@ message.
         check_fail("The epsilon should not be negative.\n" +
                     "<-0.1> was expected to be\n>=\n<0.0>.") do
           assert_not_in_epsilon(10000, 9000, -0.1, "message")
+        end
+      end
+    end
+
+    class TestAssertNotInEpsilonBigDecimal < Test::Unit::TestCase
+      include AssertionCheckable
+
+      def test_pass
+        check_nothing_fails do
+          assert_not_in_epsilon(BigDecimal("1.0000e1000"),
+                                BigDecimal("0.8999e1000"),
+                                BigDecimal("0.1"))
+        end
+      end
+
+      def test_pass_without_epsilon
+        check_nothing_fails do
+          assert_not_in_epsilon(BigDecimal("1.0000e1000"),
+                                BigDecimal("0.9989e1000"))
+        end
+      end
+
+      def test_pass_with_message
+        check_nothing_fails do
+          assert_not_in_epsilon(BigDecimal("1.0000e1000"),
+                                BigDecimal("0.8999e1000"),
+                                BigDecimal("0.1"),
+                                "message")
+        end
+      end
+
+      def test_pass_float_like_object
+        check_nothing_fails do
+          float_thing = Object.new
+          def float_thing.to_f
+            8999.0
+          end
+          assert_not_in_epsilon(BigDecimal("10000"),
+                                float_thing,
+                                BigDecimal("0.1"))
+        end
+      end
+
+      def test_pass_string_epxected
+        check_nothing_fails do
+          assert_not_in_epsilon("10000",
+                                BigDecimal("8999"),
+                                BigDecimal("0.1"))
+        end
+      end
+
+      def test_fail
+        check_fail("<0.1e1001> -/+ (<0.1e1001> * <0.1e0>)[0.1e1000] " +
+                    "was expected to not include\n" +
+                    "<0.9e1000>.\n" +
+                    "\n" +
+                    "Relation:\n" +
+                    "<" +
+                    "<0.1e1001>-(<0.1e1001>*<0.1e0>)[0.9e1000] <= " +
+                    "<0.9e1000> <= " +
+                    "<0.1e1001>+(<0.1e1001>*<0.1e0>)[0.11e1001]" +
+                    ">") do
+          assert_not_in_epsilon(BigDecimal("1.0e1000"),
+                                BigDecimal("0.9e1000"),
+                                BigDecimal("0.1"))
+        end
+      end
+
+      def test_fail_without_epsilon
+        check_fail("<0.1e1001> -/+ (<0.1e1001> * <0.001>)[0.1e998] " +
+                    "was expected to not include\n" +
+                    "<0.999e1000>.\n" +
+                    "\n" +
+                    "Relation:\n" +
+                    "<" +
+                    "<0.1e1001>-(<0.1e1001>*<0.001>)[0.999e1000] <= " +
+                    "<0.999e1000> <= " +
+                    "<0.1e1001>+(<0.1e1001>*<0.001>)[0.1001e1001]" +
+                    ">") do
+          assert_not_in_epsilon(BigDecimal("1.000e1000"),
+                                BigDecimal("0.999e1000"))
+        end
+      end
+
+      def test_fail_with_message
+        check_fail("message.\n" +
+                    "<0.1e1001> -/+ (<0.1e1001> * <0.1e0>)[0.1e1000] " +
+                    "was expected to not include\n" +
+                    "<0.9e1000>.\n" +
+                    "\n" +
+                    "Relation:\n" +
+                    "<" +
+                    "<0.1e1001>-(<0.1e1001>*<0.1e0>)[0.9e1000] <= " +
+                    "<0.9e1000> <= " +
+                    "<0.1e1001>+(<0.1e1001>*<0.1e0>)[0.11e1001]" +
+                    ">") do
+          assert_not_in_epsilon(BigDecimal("1.0e1000"),
+                                BigDecimal("0.9e1000"),
+                                BigDecimal("0.1"),
+                                "message")
+        end
+      end
+
+      def test_fail_because_not_float_like_object
+        object = Object.new
+        inspected_object = AssertionMessage.convert(object)
+        check_fail("The arguments must respond to to_f; " +
+                    "the first float did not.\n" +
+                    "<#{inspected_object}>.respond_to?(:to_f) expected\n" +
+                    "(Class: <Object>)") do
+          assert_not_in_epsilon(object,
+                                BigDecimal("0.9e1000"),
+                                BigDecimal("0.1"))
+        end
+      end
+
+      def test_fail_because_negaitve_epsilon
+        check_fail("The epsilon should not be negative.\n" +
+                    "<-0.1e0> was expected to be\n>=\n<0.0>.") do
+          assert_not_in_epsilon(BigDecimal("10000"),
+                                BigDecimal("9000"),
+                                BigDecimal("-0.1"),
+                                "message")
         end
       end
     end

--- a/test/testunit-test-util.rb
+++ b/test/testunit-test-util.rb
@@ -1,5 +1,6 @@
 require "objspace"
 require "tempfile"
+require "bigdecimal"
 
 module TestUnitTestUtil
   private


### PR DESCRIPTION
This accepts `BigDecimal` as input without converting `Float` implicitly for `assert_in_delta` and its family.