### PR TITLE
Fix ivar name

### DIFF
--- a/lib/test/unit/attribute.rb
+++ b/lib/test/unit/attribute.rb
@@ -199,7 +199,7 @@ module Test
               ancestor.is_a?(Class) and
               ancestor < Test::Unit::Attribute
           end
-          return nil if @cached_parent_test.nil?
+          return nil if @cached_parent_test_case.nil?
 
           @cached_parent_test_case.find_attribute(method_name, name, options)
         end


### PR DESCRIPTION
Found in [ruby 2.7](https://github.com/kachick/ruby-gem-template/actions/runs/3179027537/jobs/5181100027), it makes warnings `warning: instance variable @cached_parent_test not initialized`

Looks related to 3058e8ac0c05a4851da4ce27830df3947f2618e8