### PR TITLE
Support partially loaded `PowerAssert` library

### DIFF
--- a/lib/test/unit/util/backtracefilter.rb
+++ b/lib/test/unit/util/backtracefilter.rb
@@ -12,7 +12,7 @@ module Test
         TESTUNIT_RB_FILE = /\.rb\Z/
 
         POWERASSERT_PREFIX =
-          defined?(::PowerAssert) ?
+          (defined?(::PowerAssert) and ::PowerAssert.respond_to?(:start)) ?
             ::PowerAssert.method(:start).source_location[0].split(TESTUNIT_FILE_SEPARATORS)[0..-2] :
             nil
 


### PR DESCRIPTION
This kind of partial loading could happen when underlying gems are
unavailable on some platforms (e.g. io/console/size on WebAssembly), and
so on.
