### PR TITLE
Reduce execution time for skipping duplicate test_cases

### DIFF
--- a/lib/test/unit/collector/load.rb
+++ b/lib/test/unit/collector/load.rb
@@ -39,7 +39,8 @@ module Test
             froms = @default_test_paths if froms.empty?
             froms = ["."] if froms.empty?
             test_suites = []
-            already_gathered = find_test_cases
+            already_gathered = {}
+            find_test_cases(already_gathered)
             froms.each do |from|
               from = resolve_path(from)
               if from.directory?
@@ -66,12 +67,13 @@ module Test
           end
         end
 
-        def find_test_cases(ignore=[])
+        def find_test_cases(ignore={})
           test_cases = []
           TestCase::DESCENDANTS.each do |test_case|
-            test_cases << test_case unless ignore.include?(test_case)
+            next if ignore.key?(test_case)
+            test_cases << test_case
+            ignore[test_case] = true
           end
-          ignore.concat(test_cases)
           test_cases
         end
 

--- a/lib/test/unit/collector/load.rb
+++ b/lib/test/unit/collector/load.rb
@@ -67,12 +67,12 @@ module Test
           end
         end
 
-        def find_test_cases(ignore={})
+        def find_test_cases(already_gathered)
           test_cases = []
           TestCase::DESCENDANTS.each do |test_case|
-            next if ignore.key?(test_case)
+            next if already_gathered.key?(test_case)
             test_cases << test_case
-            ignore[test_case] = true
+            already_gathered[test_case] = true
           end
           test_cases
         end


### PR DESCRIPTION
Test::Unit::Collector::Load#collect takes a long time when there are a large number of test files.
This PR aims to reduce the execution time."

Reproduce code(`t.rb`):

```ruby
require 'test/unit'
require 'tmpdir'

ARGV.shift
files, tests = ARGV.shift(2).map(&:to_i)

Dir.mktmpdir do |dir|
  files.times do |i|
    File.write("#{dir}/#{i}_test.rb", <<~SCRIPT)
      class Test#{i} < Test::Unit::TestCase
        #{Array.new(tests) { |j| "  def test_#{j}; end" }.join("\n")}
      end
    SCRIPT
  end
  Test::Unit::AutoRunner.run(true, dir)
end
```

Benchmark:

```bash
ruby -r benchmark -e 'Benchmark.bmbm {|x| [[1000,10],[100,100],[10,1000]].each {|f,t| x.report("#{f},#{t}") { system "ruby -Ilib t.rb -- #{f} #{t} >/dev/null" } }}'
```

master

```
Rehearsal -------------------------------------------
1000,10   0.000037   0.000432   7.585316 (  7.691274)
100,100   0.000044   0.000518   0.334060 (  0.350968)
10,1000   0.000049   0.000464   0.283171 (  0.307798)
---------------------------------- total: 8.202547sec

              user     system      total        real
1000,10   0.000039   0.000397   7.840370 (  7.959293)
100,100   0.000044   0.000525   0.332246 (  0.349655)
10,1000   0.000048   0.000512   0.287165 (  0.311607)
```

this pr

```
Rehearsal -------------------------------------------
1000,10   0.000035   0.000418   0.862495 (  0.954511)
100,100   0.000052   0.000542   0.325512 (  0.340582)
10,1000   0.000035   0.000439   0.286191 (  0.317912)
---------------------------------- total: 1.474198sec

              user     system      total        real
1000,10   0.000035   0.000410   0.837767 (  0.937692)
100,100   0.000035   0.000457   0.324251 (  0.342782)
10,1000   0.000036   0.000445   0.280969 (  0.304897)
```