### PR TITLE
doc: Use https instead of http

### DIFF
--- a/test-unit.gemspec
+++ b/test-unit.gemspec
@@ -15,7 +15,7 @@ version = Test::Unit::VERSION.dup
 Gem::Specification.new do |spec|
   spec.name = "test-unit"
   spec.version = version
-  spec.homepage = "http://test-unit.github.io/"
+  spec.homepage = "https://test-unit.github.io/"
   spec.authors = ["Kouhei Sutou", "Haruka Yoshihara"]
   spec.email = ["kou@cozmixng.org", "yoshihara@clear-code.com"]
   readme = File.read("README.md")


### PR DESCRIPTION
Because avoid unnecessary redirects.