### PR TITLE
Support Ruby 3.4's new error message format

### DIFF
--- a/lib/test/unit/fault-location-detector.rb
+++ b/lib/test/unit/fault-location-detector.rb
@@ -18,7 +18,7 @@ module Test
         return nil if match_data.nil?
         file, line_number, context = match_data.to_a[1..-1]
         line_number = line_number.to_i
-        if /\Ain `(.+?)'/ =~ context
+        if /\Ain [`'](.+?)'/ =~ context
           method_name = $1
           if /\Ablock (?:\(.+?\) )?in / =~ method_name
             method_name = $POSTMATCH

--- a/test/test-test-case.rb
+++ b/test/test-test-case.rb
@@ -65,7 +65,7 @@ module Test
         entry.start_with?("<internal:")
       end
 
-      def normalize_backtrace(location)
+      def normalize_location(location)
         filtered_location = location.reject do |entry|
           jruby_backtrace_entry?(entry) or
             rubinius_backtrace_entry?(entry) or
@@ -96,7 +96,7 @@ module Test
             :class     => fault.class,
             :message   => fault.message,
             :test_name => fault.test_name,
-            :location  => normalize_backtrace(fault.location),
+            :location  => normalize_location(fault.location),
           }
         end
         assert_equal([
@@ -142,7 +142,7 @@ module Test
             :class     => fault.class,
             :message   => fault.message,
             :test_name => fault.test_name,
-            :location  => normalize_backtrace(fault.location),
+            :location  => normalize_location(fault.location),
           }
         end
         assert_equal([
@@ -194,7 +194,7 @@ module Test
             :class     => fault.class,
             :message   => fault.message,
             :test_name => fault.test_name,
-            :location  => normalize_backtrace(fault.location),
+            :location  => normalize_location(fault.location),
           }
         end
         location = []

--- a/test/test-test-case.rb
+++ b/test/test-test-case.rb
@@ -65,14 +65,14 @@ module Test
         entry.start_with?("<internal:")
       end
 
-      def normalize_location(location)
+      def normalize_backtrace(location)
         filtered_location = location.reject do |entry|
           jruby_backtrace_entry?(entry) or
             rubinius_backtrace_entry?(entry) or
             internal_backtrace_entry?(entry)
         end
         filtered_location.collect do |entry|
-          entry.sub(/:\d+:/, ":0:")
+          entry.sub(/:\d+:/, ":0:").sub(/in [`'](?:[^']+?[#.])?/, "in '")
         end
       end
 
@@ -96,7 +96,7 @@ module Test
             :class     => fault.class,
             :message   => fault.message,
             :test_name => fault.test_name,
-            :location  => normalize_location(fault.location),
+            :location  => normalize_backtrace(fault.location),
           }
         end
         assert_equal([
@@ -105,8 +105,8 @@ module Test
                          :message   => "failure",
                          :test_name => "test_failure(TC_FailureError)",
                          :location  => [
-                           "#{__FILE__}:0:in `test_failure'",
-                           "#{__FILE__}:0:in `#{__method__}'",
+                           "#{__FILE__}:0:in 'test_failure'",
+                           "#{__FILE__}:0:in '#{__method__}'",
                          ],
                        },
                      ],
@@ -142,7 +142,7 @@ module Test
             :class     => fault.class,
             :message   => fault.message,
             :test_name => fault.test_name,
-            :location  => normalize_location(fault.location),
+            :location  => normalize_backtrace(fault.location),
           }
         end
         assert_equal([
@@ -151,9 +151,9 @@ module Test
                          :message   => "nested",
                          :test_name => "test_nested_failure(TC_FailureError)",
                          :location  => [
-                           "#{__FILE__}:0:in `nested'",
-                           "#{__FILE__}:0:in `test_nested_failure'",
-                           "#{__FILE__}:0:in `#{__method__}'",
+                           "#{__FILE__}:0:in 'nested'",
+                           "#{__FILE__}:0:in 'test_nested_failure'",
+                           "#{__FILE__}:0:in '#{__method__}'",
                          ],
                        },
                      ],
@@ -194,13 +194,13 @@ module Test
             :class     => fault.class,
             :message   => fault.message,
             :test_name => fault.test_name,
-            :location  => normalize_location(fault.location),
+            :location  => normalize_backtrace(fault.location),
           }
         end
         location = []
-        location << "#{__FILE__}:0:in `/'" if cruby?
-        location << "#{__FILE__}:0:in `test_error'"
-        location << "#{__FILE__}:0:in `#{__method__}'"
+        location << "#{__FILE__}:0:in '/'" if cruby?
+        location << "#{__FILE__}:0:in 'test_error'"
+        location << "#{__FILE__}:0:in '#{__method__}'"
         assert_equal([
                        {
                          :class     => Error,

--- a/test/test-test-case.rb
+++ b/test/test-test-case.rb
@@ -72,7 +72,7 @@ module Test
             internal_backtrace_entry?(entry)
         end
         filtered_location.collect do |entry|
-          entry.sub(/:\d+:/, ":0:").sub(/in [`'](?:[^']+?[#.])?/, "in '")
+          entry.sub(/:\d+:in [`'](?:[^']+?[#.])?/, ":0:in '")
         end
       end
 

--- a/test/util/test_backtracefilter.rb
+++ b/test/util/test_backtracefilter.rb
@@ -40,7 +40,7 @@ module Test::Unit::Util
 
     def test_power_assert_backtrace
       omit('test for power_assert') unless defined?(PowerAssert)
-      blk = Proc.new {caller.find {|i| /power_assert.*in \`start\'/ =~ i}}
+      blk = Proc.new {caller.find {|i| /power_assert.*in [`'](?:PowerAssert\.)?start\'/ =~ i}}
       PowerAssert.start(blk) do |pa|
         backtrace = [pa.yield,
           %q{tc_thing.rb:4:in 'a'},


### PR DESCRIPTION
Ruby 3.4 will use a single quote instead of a backtrick as an open quote.

https://bugs.ruby-lang.org/issues/16495

Also, the backtrace line will have not only a method name but also its receiver class.

https://bugs.ruby-lang.org/issues/19117