### PR TITLE
testsuite: Remove unneeded cache

### DIFF
--- a/lib/test/unit/testsuite.rb
+++ b/lib/test/unit/testsuite.rb
@@ -37,7 +37,6 @@ module Test
         @priority = 0
         @start_time = nil
         @elapsed_time = nil
-        @passed = true
       end
 
       # Runs the tests and/or suites contained in this
@@ -99,7 +98,7 @@ module Test
       end
 
       def passed?
-        @passed
+        @tests.all?(&:passed?)
       end
 
       private
@@ -115,7 +114,6 @@ module Test
       def run_tests(result, &progress_block)
         @tests.each do |test|
           run_test(test, result, &progress_block)
-          @passed = false unless test.passed?
         end
       end
 
@@ -168,7 +166,6 @@ module Test
           false
         else
           result.add_error(Error.new(@test_case.name, exception))
-          @passed = false
           true
         end
       end


### PR DESCRIPTION
Use `Array#each` instead of `Array#shift` in GH-240.

Before GH-240 change:

`Array#shift` **removes** and returns leading elements. So after removing, it cached `TestCase#passed?` or `TestSuite#passed?` results to `@passed`.

After this change:

`Array#each` iterates over array elements, **without removing** them. Using `Array#each` instead of `Array#shift`, means there's no need to cached `TestCase#passed?` or `TestSuite#passed?` results to `@passed`.

Note:

Since `@passed = true` was set in `TestSuite#initialize`, it should default to true when there are no tests.

`Array#all?` returns true for an empty array below. The behavior remains unchanged, so there's no issue.

```ruby
[].all? { true }
# => true
```

for future parallelization support. Part of GH-235.