### PR TITLE
Use TestSuiteRunner for a system global

### DIFF
--- a/lib/test/unit/test-suite-runner.rb
+++ b/lib/test/unit/test-suite-runner.rb
@@ -9,6 +9,13 @@
 module Test
   module Unit
     class TestSuiteRunner
+      class << self
+        def run(test_suite, result, &progress_block)
+          runner = new(test_suite)
+          runner.run(result, &progress_block)
+        end
+      end
+
       def initialize(test_suite)
         @test_suite = test_suite
       end

--- a/lib/test/unit/testsuite.rb
+++ b/lib/test/unit/testsuite.rb
@@ -43,8 +43,7 @@ module Test
       # Runs the tests and/or suites contained in this
       # TestSuite.
       def run(result, &progress_block)
-        runner = TestSuiteRunner.new(self)
-        runner.run(result) do |event, *args|
+        TestSuiteRunner.run(self, result) do |event, *args|
           case event
           when STARTED
             @start_time = Time.now


### PR DESCRIPTION
We want to switch the backend (`TestSuiteRunner`) with an option.

Currently, it operates sequentially, but we want to switch it to a `Thread` based or other parallel runner. `TestSuiteRunner` is hardcoded to invoke within `TestSuite#run`. It cannot be modified externally, so we need to implement a mechanism to enable external modification.

We guess two main approaches:

* Stop invoking the runner inside and instead accept it from the outside
* Allow injection of the runner from the outside

We considered the following approaches:

1. Pass the Runner as a `TestSuite#run` argument

    Seems broken as the interface might change

    ```ruby
    # `TestSuiteRunner#run_test`
    test.run(result) do |event_name, *args|
    ```

    Here, `test` is a `TestCase` or `TestSuite` object. If it's
    `TestCase`, use this argument. If it's `TestSuite`, use that
    argument... Seems does not make sense

2. Pass the Runner as a `TestSuite#initialize` argument

    Switch the backend per `TestSuite`.

    When grouping `TestCase`, `TestSuite` are nested. Executing a single
    `TestSuite`, multiple `TestSuite` needs to be run. Seems does not
    make sense.

3. Use `TestSuiteRunner` for a system global

    It's uncommon to switch test runners per test suite, so it's better
    to handle it globally.

    e.g.:

    ```ruby
    # `TestSuiteRunner.run`
    class << self
      def run(test_suite, result, &progress_block)
      end
    end
    ```

    Seems to make sense.

We've decided to implement approach 3. We've inserted an abstracted layer. After, by replacing `TestSuiteRunner.run` from the outside.

for future parallelization support. Part of GH-235.