### PR TITLE
Make backend possible to switch globally

### DIFF
--- a/lib/test/unit/test-suite-runner.rb
+++ b/lib/test/unit/test-suite-runner.rb
@@ -9,10 +9,15 @@
 module Test
   module Unit
     class TestSuiteRunner
+      @default = self
       class << self
         def run(test_suite, result, &progress_block)
-          runner = new(test_suite)
+          runner = @default.new(test_suite)
           runner.run(result, &progress_block)
+        end
+
+        def default=(runner_class)
+          @default = runner_class
         end
       end
 


### PR DESCRIPTION
`TestSuite` only invokes `TestSuiteRunner.run` (not `.run` of parallel runners such as `Thread` base).

As a result, parallel runners don't need to store the default runner, so they use instance variables rather than class variables.

for future parallelization support. Part of GH-235.