### PR TITLE
Add --[no-]parallel option

### DIFF
--- a/lib/test/unit/autorunner.rb
+++ b/lib/test/unit/autorunner.rb
@@ -401,6 +401,20 @@ module Test
             @gc_stress = boolean
           end
 
+          parallel_options = [
+            :thread,
+          ]
+          o.on("--[no-]parallel=[thread]", parallel_options,
+               "Runs tests in parallel",
+               "(default is thread)") do |parallel|
+            case parallel
+            when nil, :thread
+              TestSuiteRunner.default = TestSuiteThreadRunner
+            else
+              TestSuiteRunner.default = TestSuiteRunner
+            end
+          end
+
           ADDITIONAL_OPTIONS.each do |option_builder|
             option_builder.call(self, o)
           end


### PR DESCRIPTION
Add support for switching the backend such as `Thread`. Please note that
the `Thread` based runner is not yet available (raises `NameError`).

Examples:

* `ruby -I lib test/run-test.rb --parallel`: `Thread`
* `ruby -I lib test/run-test.rb --parallel=thread`: `Thread`
* `ruby -I lib test/run-test.rb --no-parallel`: Sequential
* `ruby -I lib test/run-test.rb` (no --parallel option): Sequential

Note:

We considered the following other options.

1. `--runner` option:
    * Already exists but is used to switch the UI execution
    * UI execution and internal parallelism are independent
    * Seems does not make sense
2. `--executer` option
    * Does not exist
    * `TestSuiteRunner` has run methods (not execute)
    * Seems does not make sense

for future parallelization support. Part of GH-235.