### PR TITLE
Add --n-workers option

### DIFF
--- a/lib/test/unit/autorunner.rb
+++ b/lib/test/unit/autorunner.rb
@@ -415,6 +415,12 @@ module Test
             end
           end
 
+          o.on("--n-workers=N", Integer,
+               "The number of parallelism",
+               "(#{TestSuiteRunner.n_workers})") do |n|
+            TestSuiteRunner.n_workers = n
+          end
+
           ADDITIONAL_OPTIONS.each do |option_builder|
             option_builder.call(self, o)
           end

--- a/lib/test/unit/test-suite-runner.rb
+++ b/lib/test/unit/test-suite-runner.rb
@@ -12,7 +12,7 @@ module Test
   module Unit
     class TestSuiteRunner
       @default = self
-      @n_workers = Etc.nprocessors
+      @n_workers = Etc.respond_to?(:nprocessors) ? Etc.nprocessors : 1
       class << self
         def run(test_suite, result, &progress_block)
           runner = @default.new(test_suite)

--- a/lib/test/unit/test-suite-runner.rb
+++ b/lib/test/unit/test-suite-runner.rb
@@ -10,7 +10,7 @@ module Test
   module Unit
     class TestSuiteRunner
       @default = self
-      @n_workers = 5
+      @n_workers = Etc.nprocessors
       class << self
         def run(test_suite, result, &progress_block)
           runner = @default.new(test_suite)

--- a/lib/test/unit/test-suite-runner.rb
+++ b/lib/test/unit/test-suite-runner.rb
@@ -6,6 +6,8 @@
 # Copyright:: Copyright (c) 2024 Tsutomu Katsube. All rights reserved.
 # License:: Ruby license.
 
+require "etc"
+
 module Test
   module Unit
     class TestSuiteRunner

--- a/lib/test/unit/test-suite-runner.rb
+++ b/lib/test/unit/test-suite-runner.rb
@@ -10,6 +10,7 @@ module Test
   module Unit
     class TestSuiteRunner
       @default = self
+      @n_workers = 5
       class << self
         def run(test_suite, result, &progress_block)
           runner = @default.new(test_suite)
@@ -18,6 +19,14 @@ module Test
 
         def default=(runner_class)
           @default = runner_class
+        end
+
+        def n_workers
+          @n_workers
+        end
+
+        def n_workers=(n)
+          @n_workers = n
         end
       end
 


### PR DESCRIPTION
Add switching the number of parallelism (the default value is the number of online processors in Ruby 2.2.0 or later, but fixed them to 1 for old Ruby). Please note that the `Thread` based runner is not yet available (raises `NameError`).

Note:

We considered the number of parallelism option names below:

1. `--n-threads`
    * Backend is not just about `Thread`
    * Seems does not make sense
2. `--jobs`
    * We don't call this a job
    * Seems does not make sense
3. `--n-workers`
    * We already call this a worker
    * Seems make sense

for future parallelization support. Part of GH-235.