### PR TITLE
Add --[no-]report-slow-tests option

### DIFF
--- a/lib/test/unit/runner/console.rb
+++ b/lib/test/unit/runner/console.rb
@@ -9,6 +9,7 @@ module Test
 
     AutoRunner.setup_option do |auto_runner, opts|
       require 'test/unit/ui/console/outputlevel'
+      require 'test/unit/ui/console/testrunner'
 
       output_levels = [
         ["silent", UI::Console::OutputLevel::SILENT],
@@ -72,6 +73,13 @@ module Test
               "Shows fault details in reverse.",
               "(default is yes for tty output, no otherwise)") do |boolean|
         auto_runner.runner_options[:reverse_output] = boolean
+      end
+
+      n_report_slow_tests = UI::Console::TestRunner::N_REPORT_SLOW_TESTS
+      opts.on("--[no-]report-slow-tests",
+              "Shows the top #{n_report_slow_tests} slow tests in the summary output",
+              "(false)") do |boolean|
+        auto_runner.runner_options[:report_slow_tests] = boolean
       end
     end
   end

--- a/lib/test/unit/ui/console/testrunner.rb
+++ b/lib/test/unit/ui/console/testrunner.rb
@@ -29,6 +29,8 @@ module Test
         class TestRunner < UI::TestRunner
           include OutputLevel
 
+          N_REPORT_SLOW_TESTS = 5
+
           # Creates a new TestRunner for running the passed
           # suite. If quiet_mode is true, the output while
           # running is limited to progress dots, errors and
@@ -59,6 +61,8 @@ module Test
             @faults = []
             @code_snippet_fetcher = CodeSnippetFetcher.new
             @test_suites = []
+            @report_slow_tests = @options[:report_slow_tests]
+            @report_slow_tests = false if @report_slow_tests.nil?
           end
 
           private

--- a/lib/test/unit/ui/console/testrunner.rb
+++ b/lib/test/unit/ui/console/testrunner.rb
@@ -61,8 +61,6 @@ module Test
             @faults = []
             @code_snippet_fetcher = CodeSnippetFetcher.new
             @test_suites = []
-            @report_slow_tests = @options[:report_slow_tests]
-            @report_slow_tests = false if @report_slow_tests.nil?
           end
 
           private


### PR DESCRIPTION
Add support for showing the top 5 slow tests in the summary output.

Please note that at this step, specifying the option will result is no change.

Refs GH-253.