### PR TITLE
test fault-location-detector: use class instance vars to fix scope issue

### DIFF
--- a/test/test-fault-location-detector.rb
+++ b/test/test-fault-location-detector.rb
@@ -112,11 +112,11 @@ class TestFaultLocationDetector < Test::Unit::TestCase
 
         class << self
           def target_line_number
-            @@target_line_number
+            @target_line_number
           end
 
           def target_line_number=(line_number)
-            @@target_line_number = line_number
+            @target_line_number = line_number
           end
         end
 
@@ -134,11 +134,11 @@ class TestFaultLocationDetector < Test::Unit::TestCase
 
       class << self
         def target_line_number
-          @@target_line_number
+          @target_line_number
         end
 
         def target_line_number=(line_number)
-          @@target_line_number = line_number
+          @target_line_number = line_number
         end
       end
     end
@@ -161,11 +161,11 @@ class TestFaultLocationDetector < Test::Unit::TestCase
 
         class << self
           def target_line_number
-            @@target_line_number
+            @target_line_number
           end
 
           def target_line_number=(line_number)
-            @@target_line_number = line_number
+            @target_line_number = line_number
           end
         end
 


### PR DESCRIPTION
Because a class variable is scoped to the innermost enclosing class or module keywords. This scope does not include singleton class.