### PR TITLE
Collect the top 5 slow tests in descending order

### DIFF
--- a/lib/test/unit/ui/console/testrunner.rb
+++ b/lib/test/unit/ui/console/testrunner.rb
@@ -424,7 +424,7 @@ module Test
           end
 
           def test_started(test)
-            return unless output?(VERBOSE) || @options[:report_slow_tests]
+            return unless output?(VERBOSE)
 
             tab_width = 8
             name = test.local_name
@@ -461,15 +461,17 @@ module Test
             end
             @already_outputted = false
 
-            return unless output?(VERBOSE) || @options[:report_slow_tests]
+            if @options[:report_slow_tests]
+              @slow_tests << {
+                name: test.name,
+                elapsed_time: test.elapsed_time,
+                location: test.method(test.method_name).source_location.join(":"),
+              }
+            end
 
-            elapsed_time = Time.now - @test_start
-            output(": (%f)" % (elapsed_time), nil, VERBOSE)
-            @slow_tests << {
-              name: test.name,
-              elapsed_time: elapsed_time,
-              location: test.method(test.method_name).source_location.join(":"),
-            }
+            return unless output?(VERBOSE)
+
+            output(": (%f)" % (Time.now - @test_start), nil, VERBOSE)
           end
 
           def suite_name(prefix, suite)

--- a/lib/test/unit/ui/console/testrunner.rb
+++ b/lib/test/unit/ui/console/testrunner.rb
@@ -61,7 +61,7 @@ module Test
             @faults = []
             @code_snippet_fetcher = CodeSnippetFetcher.new
             @test_suites = []
-            @slow_tests = []
+            @test_statistics = []
           end
 
           private
@@ -396,9 +396,9 @@ module Test
               output("Finished in #{elapsed_time} seconds.")
             end
             if @options[:report_slow_tests]
-              @slow_tests.sort_by { |slow_test| -slow_test[:elapsed_time] }
-                         .first(N_REPORT_SLOW_TESTS)
-                         .each do |slow_test|
+              @test_statistics.sort_by { |slow_test| -slow_test[:elapsed_time] }
+                              .first(N_REPORT_SLOW_TESTS)
+                              .each do |slow_test|
               end
             end
             output_summary_marker
@@ -462,7 +462,7 @@ module Test
             @already_outputted = false
 
             if @options[:report_slow_tests]
-              @slow_tests << {
+              @test_statistics << {
                 name: test.name,
                 elapsed_time: test.elapsed_time,
                 location: test.method(test.method_name).source_location.join(":"),

--- a/lib/test/unit/ui/console/testrunner.rb
+++ b/lib/test/unit/ui/console/testrunner.rb
@@ -396,7 +396,7 @@ module Test
               output("Finished in #{elapsed_time} seconds.")
             end
             if @options[:report_slow_tests]
-              @test_statistics.sort_by { |slow_test| -slow_test[:elapsed_time] }
+              @test_statistics.sort_by {|slow_test| -slow_test[:elapsed_time]}
                               .first(N_REPORT_SLOW_TESTS)
                               .each do |slow_test|
               end

--- a/lib/test/unit/ui/console/testrunner.rb
+++ b/lib/test/unit/ui/console/testrunner.rb
@@ -396,9 +396,9 @@ module Test
               output("Finished in #{elapsed_time} seconds.")
             end
             if @options[:report_slow_tests]
-              @test_statistics.sort_by {|slow_test| -slow_test[:elapsed_time]}
+              @test_statistics.sort_by {|statistic| -statistic[:elapsed_time]}
                               .first(N_REPORT_SLOW_TESTS)
-                              .each do |slow_test|
+                              .each do |slow_statistic|
               end
             end
             output_summary_marker


### PR DESCRIPTION
GitHub: GH-253

This is a part of adding support for showing the top 5 slow tests in the summary output.

This just collects the top 5 slow tests in descending order of test execution time, so it doesn't show in the summary output for now.