### PR TITLE
ui console: remove a needless instance variable

### DIFF
--- a/lib/test/unit/ui/console/testrunner.rb
+++ b/lib/test/unit/ui/console/testrunner.rb
@@ -444,7 +444,6 @@ module Test
             output_single("#{indent}#{name}#{separator}#{tab_stop}",
                           nil,
                           VERBOSE)
-            @test_start = Time.now
           end
 
           def test_finished(test)
@@ -471,7 +470,7 @@ module Test
 
             return unless output?(VERBOSE)
 
-            output(": (%f)" % (Time.now - @test_start), nil, VERBOSE)
+            output(": (%f)" % test.elapsed_time, nil, VERBOSE)
           end
 
           def suite_name(prefix, suite)


### PR DESCRIPTION
Because `TestCase#elapsed_time` can be used instead of `@test_start`. And `@test_start` is only used in the `--verbose` option, so it can be removed.

By the way, `TestCase#elapsed_time` is shorter than `Time.now - @test_start` (just a little). Because it excludes the execution time of operations like `TestResult#add_run`:

```lib/test/unit/testcase.rb
      def run(result)
# (snip)
          @internal_data.test_finished
          result.add_run
          yield(FINISHED, name)
          yield(FINISHED_OBJECT, self)
# (snip)
      end
```