### PR TITLE
Show the top 5 slow tests with test name and execution time

### DIFF
--- a/lib/test/unit/ui/console/testrunner.rb
+++ b/lib/test/unit/ui/console/testrunner.rb
@@ -403,7 +403,11 @@ module Test
                               .each do |slow_statistic|
                 left_side = "#{slow_statistic[:name]}: "
                 right_width = @progress_row_max - left_side.size
-                output("#{left_side}%#{right_width}<elapsed_time>f" % slow_statistic)
+                output("%s%*f" % [
+                         left_side,
+                         right_width,
+                         slow_statistic[:elapsed_time],
+                       ])
               end
             end
             output_summary_marker

--- a/lib/test/unit/ui/console/testrunner.rb
+++ b/lib/test/unit/ui/console/testrunner.rb
@@ -396,9 +396,14 @@ module Test
               output("Finished in #{elapsed_time} seconds.")
             end
             if @options[:report_slow_tests]
+              output_summary_marker
+              output("Top #{N_REPORT_SLOW_TESTS} slow tests")
               @test_statistics.sort_by {|statistic| -statistic[:elapsed_time]}
                               .first(N_REPORT_SLOW_TESTS)
                               .each do |slow_statistic|
+                left_side = "#{slow_statistic[:name]}: "
+                right_width = @progress_row_max - left_side.size
+                output("#{left_side}%#{right_width}<elapsed_time>f" % slow_statistic)
               end
             end
             output_summary_marker


### PR DESCRIPTION
GitHub: GH-253

This is a part of adding support for showing the top 5 slow tests in the summary output.

This just show the top 5 slow tests with test name and execution time, so it doesn't show following infomation in the summary output for now.

- Test source location (easy to jump in editor)
- Command lines (easy to re-run)