### PR TITLE
Show the top 5 slow tests with --location option

### DIFF
--- a/lib/test/unit/ui/console/testrunner.rb
+++ b/lib/test/unit/ui/console/testrunner.rb
@@ -408,7 +408,7 @@ module Test
                          right_width,
                          slow_statistic[:elapsed_time],
                        ])
-                output("--location %s" % slow_statistic[:location])
+                output("--location #{slow_statistic[:location]}")
               end
             end
             output_summary_marker

--- a/lib/test/unit/ui/console/testrunner.rb
+++ b/lib/test/unit/ui/console/testrunner.rb
@@ -408,7 +408,7 @@ module Test
                          right_width,
                          slow_statistic[:elapsed_time],
                        ])
-                output(slow_statistic[:location])
+                output("--location %s" % slow_statistic[:location])
               end
             end
             output_summary_marker


### PR DESCRIPTION
GitHub: fix GH-253

This is a **final** part of adding support for showing the top 5 slow tests in the summary output.

This show the top 5 slow tests with `--location` option for easy to re-run command lines.

By the way, removing the `=` to make it easier to jump in the editor. Because including the `=` makes it difficult to jump in the editor:

```diff
-`--location=...` makes less sense than
+`--location ...`
            ^
```