### PR TITLE
Allow inspecting `BasicObject` instances without `object_id` method

### DIFF
--- a/lib/test/unit/assertions.rb
+++ b/lib/test/unit/assertions.rb
@@ -2093,7 +2093,7 @@ EOT
 
           class << self
             def cached_new(object, inspected_objects)
-              inspected_objects[object.object_id] ||=
+              inspected_objects[object.__id__] ||=
                 new(object, inspected_objects)
             end
 
@@ -2115,7 +2115,7 @@ EOT
           def initialize(object, inspected_objects={})
             @inspected_objects = inspected_objects
             @object = object
-            @inspected_objects[@object.object_id] = self
+            @inspected_objects[@object.__id__] = self
             @inspect_target = inspect_target
           end
 

--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -316,6 +316,27 @@ EOM
             end
           end
 
+          def test_basic_object_inspection
+            basic_object_class = Class.new(BasicObject) do
+              [:respond_to?, :respond_to_missing?, :is_a?].each do |m|
+                define_method(m, ::Kernel.instance_method(m))
+              end
+
+              def inspect
+                "inspected"
+              end
+            end
+            object1 = basic_object_class.new
+            object2 = basic_object_class.new
+            message = <<-EOM.chomp
+<inspected> expected but was
+<inspected>.
+EOM
+            check_fail(message) do
+              assert_equal(object1, object2)
+            end
+          end
+
           def test_multi_lines_result
             message = <<-EOM.chomp
 <#{AssertionMessage.convert("a\nb")}> expected but was


### PR DESCRIPTION
It would be nice not to rely on `object_id`, which is not guaranteed to be available for `BasicObject` instances. This change uses `__id__` to require inspectees to have minimal methods.