### PR TITLE
Add support for parallelization with Thread backend

### DIFF
--- a/lib/test/unit/autorunner.rb
+++ b/lib/test/unit/autorunner.rb
@@ -5,6 +5,7 @@ require "test/unit/color-scheme"
 require "test/unit/priority"
 require "test/unit/attribute-matcher"
 require "test/unit/testcase"
+require "test/unit/test-suite-thread-runner"
 
 module Test
   module Unit

--- a/lib/test/unit/sub-test-result.rb
+++ b/lib/test/unit/sub-test-result.rb
@@ -6,7 +6,7 @@
 
 module Test
   module Unit
-    class TestThreadResult
+    class SubTestResult
       attr_accessor :stop_tag
 
       def initialize(parent_test_result)

--- a/lib/test/unit/test-suite-thread-runner.rb
+++ b/lib/test/unit/test-suite-thread-runner.rb
@@ -4,8 +4,8 @@
 # Copyright:: Copyright (c) 2024 Tsutomu Katsube. All rights reserved.
 # License:: Ruby license.
 
-require_relative "test-suite-runner"
 require_relative "sub-test-result"
+require_relative "test-suite-runner"
 
 module Test
   module Unit

--- a/lib/test/unit/test-suite-thread-runner.rb
+++ b/lib/test/unit/test-suite-thread-runner.rb
@@ -49,10 +49,6 @@ module Test
         end
       end
 
-      def initialize(test_suite)
-        super
-      end
-
       private
       def run_tests(result, &progress_block)
         @test_suite.tests.each do |test|

--- a/lib/test/unit/test-suite-thread-runner.rb
+++ b/lib/test/unit/test-suite-thread-runner.rb
@@ -5,7 +5,7 @@
 # License:: Ruby license.
 
 require_relative "test-suite-runner"
-require_relative "test-thread-result"
+require_relative "sub-test-result"
 
 module Test
   module Unit
@@ -56,7 +56,7 @@ module Test
             run_test(test, result, &progress_block)
           else
             task = lambda do |stop_tag|
-              sub_result = TestThreadResult.new(result)
+              sub_result = SubTestResult.new(result)
               sub_result.stop_tag = stop_tag
               run_test(test, sub_result, &progress_block)
             end

--- a/lib/test/unit/test-thread-result.rb
+++ b/lib/test/unit/test-thread-result.rb
@@ -1,0 +1,51 @@
+#--
+#
+# Author:: Tsutomu Katsube.
+# Copyright:: Copyright (c) 2024 Tsutomu Katsube. All rights reserved.
+# License:: Ruby license.
+
+module Test
+  module Unit
+    class TestThreadResult
+      attr_accessor :stop_tag
+
+      def initialize(parent_test_result)
+        @parent_test_result = parent_test_result
+        @stop_tag = nil
+      end
+
+      def add_run(result = self)
+        @parent_test_result.add_run(result)
+      end
+
+      def add_pass
+        @parent_test_result.add_pass
+      end
+
+      # Records an individual assertion.
+      def add_assertion
+        @parent_test_result.add_assertion
+      end
+
+      def add_error(error)
+        @parent_test_result.add_error(error)
+      end
+
+      def add_failure(failure)
+        @parent_test_result.add_failure(failure)
+      end
+
+      def add_omission(omission)
+        @parent_test_result.add_omission(omission)
+      end
+
+      def passed?
+        @parent_test_result.passed?
+      end
+
+      def stop
+        throw @stop_tag
+      end
+    end
+  end
+end

--- a/lib/test/unit/test-thread-result.rb
+++ b/lib/test/unit/test-thread-result.rb
@@ -14,7 +14,7 @@ module Test
         @stop_tag = nil
       end
 
-      def add_run(result = self)
+      def add_run(result=self)
         @parent_test_result.add_run(result)
       end
 

--- a/lib/test/unit/testcase.rb
+++ b/lib/test/unit/testcase.rb
@@ -125,6 +125,10 @@ module Test
       AVAILABLE_ORDERS = [:alphabetic, :random, :defined] # :nodoc:
 
       class << self
+        def parallel_safe?
+          true
+        end
+
         def inherited(sub_class) # :nodoc:
           DESCENDANTS << sub_class
           super

--- a/lib/test/unit/testcase.rb
+++ b/lib/test/unit/testcase.rb
@@ -125,6 +125,27 @@ module Test
       AVAILABLE_ORDERS = [:alphabetic, :random, :defined] # :nodoc:
 
       class << self
+        # Indicates whether the test is parallel safe.
+        #
+        # Tests that this method returns `false` are executed sequentially
+        # before parallel safe tests run. This only works when the `--parallel`
+        # option is specified.
+        #
+        # @example Indicates that test_parallel_unsafe is parallel unsafe
+        #
+        #   class TestMyClass < Test::Unit::TestCase
+        #     class << self
+        #       def parallel_safe?
+        #         false
+        #       end
+        #     end
+        #
+        #     def test_parallel_unsafe
+        #       # ...
+        #     end
+        #   end
+        #
+        # @since 3.6.3
         def parallel_safe?
           true
         end

--- a/lib/test/unit/testresult.rb
+++ b/lib/test/unit/testresult.rb
@@ -51,9 +51,9 @@ module Test
       end
 
       # Records a test run.
-      def add_run
+      def add_run(result=self)
         @run_count += 1
-        notify_listeners(FINISHED, self)
+        notify_listeners(FINISHED, result)
         notify_changed
       end
 

--- a/lib/test/unit/testsuite.rb
+++ b/lib/test/unit/testsuite.rb
@@ -40,6 +40,11 @@ module Test
         @elapsed_time = nil
       end
 
+      def parallel_safe?
+        return true if @test_case.nil?
+        @test_case.parallel_safe?
+      end
+
       # Runs the tests and/or suites contained in this
       # TestSuite.
       def run(result, runner: nil, &progress_block)

--- a/test/collector/test-load.rb
+++ b/test/collector/test-load.rb
@@ -5,6 +5,12 @@ require 'test/unit'
 require 'test/unit/collector/load'
 
 class TestUnitCollectorLoad < Test::Unit::TestCase
+  class << self
+    def parallel_safe?
+      false
+    end
+  end
+
   def setup
     @previous_descendants = Test::Unit::TestCase::DESCENDANTS.dup
     Test::Unit::TestCase::DESCENDANTS.clear

--- a/test/test-data.rb
+++ b/test/test-data.rb
@@ -433,11 +433,23 @@ class TestData < Test::Unit::TestCase
     end
 
     class TestFileFormat < self
+      class << self
+        def parallel_safe?
+          false
+        end
+      end
+
       def setup
         self.class.current_attribute(:data).clear
       end
 
       class TestHeader < self
+        class << self
+          def parallel_safe?
+            false
+          end
+        end
+
         data("csv" => "header.csv",
              "tsv" => "header.tsv")
         def test_normal(file_name)

--- a/test/test-test-case.rb
+++ b/test/test-test-case.rb
@@ -1010,6 +1010,12 @@ module Test
           end
 
           class TestInheritance < self
+            class << self
+              def parallel_safe?
+                false
+              end
+            end
+
             def setup
               @original_descendants = TestCase::DESCENDANTS.dup
               TestCase::DESCENDANTS.clear


### PR DESCRIPTION
Will be available `Thread` based runner when specifying `--parallel` or
`--parallel=thread` option.

Users can indicate whether the test is parallel safe by using
`Test::Unit::TestCase.parallel_safe?`. This method returns `true` by
default, indicating that the test is parallel safe.

for future parallelization support. Part of GH-235.
