### PR TITLE
test: indicate parallel unsafe

### DIFF
--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -2905,6 +2905,12 @@ EOM
     class TestAssertNothingLeakedMemory < Test::Unit::TestCase
       include AssertionCheckable
 
+      class << self
+        def parallel_safe?
+          false
+        end
+      end
+
       def setup
         @data = "Hello!" * 100
         if ObjectSpace.respond_to?(:memsize_of)


### PR DESCRIPTION
GitHub: GH-235

Because each thread consumes memory independently when threads are run in parallel.

See also:
https://github.com/test-unit/test-unit/issues/235#issuecomment-2463192714