### PR TITLE
test: add missing test fault notifications

### DIFF
--- a/test/test-test-result.rb
+++ b/test/test-test-result.rb
@@ -79,6 +79,18 @@ module Test
         assert_equal([true, true], [called1, called2])
 
         called1, called2 = false, false
+        @my_result.add_pending(fault)
+        assert_equal([true, true], [called1, called2])
+
+        called1, called2 = false, false
+        @my_result.add_omission(fault)
+        assert_equal([true, true], [called1, called2])
+
+        called1, called2 = false, false
+        @my_result.add_notification(fault)
+        assert_equal([true, true], [called1, called2])
+
+        called1, called2 = false, false
         @my_result.add_run
         assert_equal([false, false], [called1, called2])
       end


### PR DESCRIPTION
Because pending, omission, and notification are also handled by `#notify_fault`.