### PR TITLE
thread runner: fix shutdown execution order

### DIFF
--- a/lib/test/unit/test-thread-run-context.rb
+++ b/lib/test/unit/test-thread-run-context.rb
@@ -9,10 +9,11 @@ require_relative "test-run-context"
 module Test
   module Unit
     class TestThreadRunContext < TestRunContext
-      attr_reader :queue
-      def initialize(runner_class, queue)
+      attr_reader :queue, :shutdowns
+      def initialize(runner_class, queue, shutdowns)
         super(runner_class)
         @queue = queue
+        @shutdowns = shutdowns
       end
     end
   end


### PR DESCRIPTION
GitHub: GH-235

This patch will execute the expected order in the thread runner:

Expected execution order:

1. startup
2. run test
3. shutdown

Actual execution order:

1. startup
2. shutdown
3. run test