### PR TITLE
test data: avoid thread safety issue

### DIFF
--- a/test/test-data.rb
+++ b/test/test-data.rb
@@ -178,12 +178,14 @@ class TestData < Test::Unit::TestCase
     end
   end
 
-  def setup
-    TestCalc.testing = true
-  end
+  class << self
+    def startup
+      TestCalc.testing = true
+    end
 
-  def teardown
-    TestCalc.testing = false
+    def shutdown
+      TestCalc.testing = false
+    end
   end
 
   def test_data_no_arguments_without_block


### PR DESCRIPTION
GitHub: GH-235, fix GH-283

Data driven tests sometimes fail when run in parallel based on Thread. Class variables are overwritten in the subclasses during setup/teardown, causing race conditions in a multithread environment.

We use startup/shutdown instead of setup/teardown, avoiding thread safety and preventing race conditions.