### PR TITLE
test: indicate parallel unsafe

### DIFF
--- a/test/collector/test-descendant.rb
+++ b/test/collector/test-descendant.rb
@@ -2,6 +2,12 @@ require 'test/unit'
 require 'test/unit/collector/descendant'
 
 class TestUnitCollectorDescendant < Test::Unit::TestCase
+  class << self
+    def parallel_safe?
+      false
+    end
+  end
+
   def setup
     @previous_descendants = Test::Unit::TestCase::DESCENDANTS.dup
     Test::Unit::TestCase::DESCENDANTS.clear

--- a/test/collector/test_dir.rb
+++ b/test/collector/test_dir.rb
@@ -6,6 +6,12 @@ module Test
   module Unit
     module Collector
       class TestDir < TestCase
+        class << self
+          def parallel_safe?
+            false
+          end
+        end
+
         class FileSystem
           class Directory
             def initialize(name, fs, parent=self, &block)

--- a/test/collector/test_objectspace.rb
+++ b/test/collector/test_objectspace.rb
@@ -9,6 +9,12 @@ module Test
   module Unit
     module Collector
       class TC_ObjectSpace < TestCase
+        class << self
+          def parallel_safe?
+            false
+          end
+        end
+
         def setup
           @tc1 = Class.new(TestCase) do
             self.test_order = :alphabetic


### PR DESCRIPTION
GitHub: GH-235

`test/collector/*.rb` modify `Test::Unit::TestCase::DESCENDANTS` during run tests. `Test::Unit::TestCase::DESCENDANTS` is process global, so it is not thread-safe.

This patch will fix tests that sometimes fail with `--parallel`.

See also:

https://github.com/test-unit/test-unit/issues/235#issuecomment-2613623710