### PR TITLE
test: use `#collect` directly instead of `#send`

### DIFF
--- a/test/collector/test-descendant.rb
+++ b/test/collector/test-descendant.rb
@@ -21,7 +21,7 @@ class TestUnitCollectorDescendant < Test::Unit::TestCase
   def assert_collect(expected, *collect_args)
     collector = Test::Unit::Collector::Descendant.new
     yield(collector) if block_given?
-    assert_equal(expected, collector.send(:collect, *collect_args))
+    assert_equal(expected, collector.collect(*collect_args))
   end
 
   def default_name

--- a/test/collector/test-load.rb
+++ b/test/collector/test-load.rb
@@ -440,7 +440,7 @@ EOT
       Dir.chdir(@test_dir.to_s) do
         collector = Test::Unit::Collector::Load.new
         yield(collector) if block_given?
-        actual = inspect_test_object(collector.send(:collect, *collect_args))
+        actual = inspect_test_object(collector.collect(*collect_args))
         assert_equal(expected, actual)
       end
     end


### PR DESCRIPTION
Because `Test::Unit::Collector::Load#collect` is not a private method.