### PR TITLE
Add support for command line tool

### DIFF
--- a/bin/test-unit
+++ b/bin/test-unit
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require "bundler/gem_tasks"
+
+ruby("-r test-unit -e run_test test")

--- a/bin/test-unit
+++ b/bin/test-unit
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 
-require "bundler/gem_tasks"
+require "test-unit"
 
-ruby("-r test-unit -e run_test test")
+exit(Test::Unit::AutoRunner.run(true, "test"))

--- a/bin/test-unit
+++ b/bin/test-unit
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 
-require "test-unit"
+require "test/unit"
 
 exit(Test::Unit::AutoRunner.run(true, "test"))

--- a/test-unit.gemspec
+++ b/test-unit.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.files += Dir.glob("{lib,sample}/**/*.rb")
   spec.files += Dir.glob("doc/text/**/*.*")
   spec.bindir = "bin"
-  spec.executables = Dir.glob("*", base: "bin")
+  spec.executables = Dir.glob("bin/*").collect {|file| File.basename(file)}
 
   spec.metadata = {
     "source_code_uri" => "https://github.com/test-unit/test-unit",

--- a/test-unit.gemspec
+++ b/test-unit.gemspec
@@ -28,9 +28,8 @@ Gem::Specification.new do |spec|
   spec.files += ["COPYING", "BSDL", "PSFL"]
   spec.files += Dir.glob("{lib,sample}/**/*.rb")
   spec.files += Dir.glob("doc/text/**/*.*")
-  spec.files += Dir.glob("bin/*")
   spec.bindir = "bin"
-  spec.executables = spec.files.grep(%r{\Abin/}) {|f| File.basename(f)}
+  spec.executables = Dir.glob("*", base: "bin")
 
   spec.metadata = {
     "source_code_uri" => "https://github.com/test-unit/test-unit",

--- a/test-unit.gemspec
+++ b/test-unit.gemspec
@@ -28,6 +28,9 @@ Gem::Specification.new do |spec|
   spec.files += ["COPYING", "BSDL", "PSFL"]
   spec.files += Dir.glob("{lib,sample}/**/*.rb")
   spec.files += Dir.glob("doc/text/**/*.*")
+  spec.files += Dir.glob("bin/*")
+  spec.bindir = "bin"
+  spec.executables = spec.files.grep(%r{\Abin/}) {|f| File.basename(f)}
 
   spec.metadata = {
     "source_code_uri" => "https://github.com/test-unit/test-unit",


### PR DESCRIPTION
GitHub: GH-288

This patch is the first step. `test-unit` executable just invokes
`require "test/unit"; exit(Test::Unit::AutoRunner.run(true, "test"))`
and does not support specifying test targets yet.