### PR TITLE
doc: use another built in runner

### DIFF
--- a/doc/po/ja.po
+++ b/doc/po/ja.po
@@ -580,7 +580,7 @@ msgid ""
 "the `--runner` option. Simply tack it to the end:"
 msgstr "テスト結果の出力フォーマットはコマンドラインで `--runner` オプションを指定すると変更できます。単純にこのオプションを最後に追加してください。"
 
-msgid "    ruby test/run.rb --runner tap"
+msgid "    ruby test/run.rb --runner emacs"
 msgstr ""
 
 msgid "## Configure test-unit per-project"

--- a/doc/text/how-to.md
+++ b/doc/text/how-to.md
@@ -24,7 +24,7 @@ Then it's easy to run tests via the command line with,
 The output format can be changed via the command line with
 the `--runner` option. Simply tack it to the end:
 
-    ruby test/run.rb --runner tap
+    ruby test/run.rb --runner emacs
 
 
 ## Configure test-unit per-project


### PR DESCRIPTION
GitHub: fix GH-293

Because the TAP runner has been extracted to
https://github.com/test-unit/test-unit-runner-tap