### PR TITLE
Add support .test-unit for default options

### DIFF
--- a/lib/test/unit/autorunner.rb
+++ b/lib/test/unit/autorunner.rb
@@ -171,9 +171,9 @@ module Test
         else
           load_global_config
         end
-        plaintext_config_file = ".test-unit"
-        if File.exist?(plaintext_config_file)
-          load_plaintext_config(plaintext_config_file)
+        plain_text_config_file = ".test-unit"
+        if File.exist?(plain_text_config_file)
+          load_plain_text_config(plain_text_config_file)
         end
         yield(self) if block_given?
       end
@@ -519,7 +519,7 @@ module Test
         @runner_options = @runner_options.merge(runner_options)
       end
 
-      def load_plaintext_config(file)
+      def load_plain_text_config(file)
         require "shellwords"
         File.readlines(file, chomp: true).each do |option|
           next if option.empty?

--- a/lib/test/unit/autorunner.rb
+++ b/lib/test/unit/autorunner.rb
@@ -171,6 +171,10 @@ module Test
         else
           load_global_config
         end
+        plaintext_config_file = ".test-unit"
+        if File.exist?(plaintext_config_file)
+          load_plaintext_config(plaintext_config_file)
+        end
         yield(self) if block_given?
       end
 
@@ -513,6 +517,15 @@ module Test
           end
         end
         @runner_options = @runner_options.merge(runner_options)
+      end
+
+      def load_plaintext_config(file)
+        require "shellwords"
+        File.readlines(file, chomp: true).each do |option|
+          next if option.empty?
+          args = Shellwords.shellsplit(option)
+          @default_arguments.concat(args)
+        end
       end
 
       private

--- a/lib/test/unit/autorunner.rb
+++ b/lib/test/unit/autorunner.rb
@@ -521,9 +521,9 @@ module Test
 
       def load_plain_text_config(file)
         require "shellwords"
-        File.readlines(file, chomp: true).each do |option|
-          next if option.empty?
-          args = Shellwords.shellsplit(option)
+        File.readlines(file, chomp: true).each do |line|
+          next if line.empty?
+          args = Shellwords.shellsplit(line)
           @default_arguments.concat(args)
         end
       end


### PR DESCRIPTION
GitHub: fix GH-300

Prefer `.test-unit` than `test-unit.yml` or `~/test-unit.yml`