### PR TITLE
testcase: remove needless instance variables added during test runs

### DIFF
--- a/lib/test/unit/testcase.rb
+++ b/lib/test/unit/testcase.rb
@@ -580,6 +580,7 @@ module Test
       def run(result, run_context: nil)
         begin
           @_result = result
+          instance_variables_before = instance_variables
           @internal_data.run_context = run_context
           @internal_data.test_started
           yield(STARTED, name)
@@ -622,6 +623,9 @@ module Test
           yield(FINISHED_OBJECT, self)
         ensure
           # @_result = nil # For test-spec's after_all :<
+          (instance_variables - instance_variables_before).each do |name|
+            remove_instance_variable(name)
+          end
         end
       end
 

--- a/test/test-fixture.rb
+++ b/test/test-fixture.rb
@@ -84,8 +84,10 @@ class TestUnitFixture < Test::Unit::TestCase
       test_case = Class.new(parent || Test::Unit::TestCase) do
         yield(self, :before) if block_given?
 
-        def called_ids
-          @called_ids ||= []
+        attr_reader :called_ids
+        def initialize(test_method_name)
+          @called_ids = []
+          super
         end
 
         def called(id)
@@ -252,8 +254,10 @@ class TestUnitFixture < Test::Unit::TestCase
 
     def test_with_exception
       test_case = Class.new(Test::Unit::TestCase) do
-        def called_ids
-          @called_ids ||= []
+        attr_reader :called_ids
+        def initialize(test_method_name)
+          @called_ids = []
+          super
         end
 
         def called(id)
@@ -300,8 +304,10 @@ class TestUnitFixture < Test::Unit::TestCase
       test_case = Class.new(parent || Test::Unit::TestCase) do
         yield(self, :before) if block_given?
 
-        def called_ids
-          @called_ids ||= []
+        attr_reader :called_ids
+        def initialize(test_method_name)
+          @called_ids = []
+          super
         end
 
         def called(id)
@@ -466,8 +472,10 @@ class TestUnitFixture < Test::Unit::TestCase
 
     def test_with_exception
       test_case = Class.new(Test::Unit::TestCase) do
-        def called_ids
-          @called_ids ||= []
+        attr_reader :called_ids
+        def initialize(test_method_name)
+          @called_ids = []
+          super
         end
 
         def called(id)
@@ -537,8 +545,10 @@ class TestUnitFixture < Test::Unit::TestCase
 
     def test_setup_with_block
       test_case = Class.new(Test::Unit::TestCase) do
-        def called_ids
-          @called_ids ||= []
+        attr_reader :called_ids
+        def initialize(test_method_name)
+          @called_ids = []
+          super
         end
 
         def called(id)
@@ -594,8 +604,10 @@ class TestUnitFixture < Test::Unit::TestCase
       test_case = Class.new(parent || Test::Unit::TestCase) do
         yield(self, :before) if block_given?
 
-        def called_ids
-          @called_ids ||= []
+        attr_reader :called_ids
+        def initialize(test_method_name)
+          @called_ids = []
+          super
         end
 
         def called(id)

--- a/test/test-test-case.rb
+++ b/test/test-test-case.rb
@@ -565,6 +565,18 @@ module Test
                      result.summary)
       end
 
+      def test_gc
+        test_case = Class.new(TestCase) do
+          def test_set_instance_variable
+            @variable = "anything"
+          end
+        end
+
+        test = test_case.new("test_set_instance_variable")
+        test.run(TestResult.new) {}
+        assert_nil(test.instance_variable_get(:@variable))
+      end
+
       private
       def check(message, passed)
         add_assertion


### PR DESCRIPTION
GitHub: GH-235

Since c26354f, instance variables add during test runs persisted longer than before. This patch ensures they are garbage collected at any time after each test run.

Reported by akira yamada. Thanks!!!