### PR TITLE
Use require_relative instead of autoload

### DIFF
--- a/lib/test-unit.rb
+++ b/lib/test-unit.rb
@@ -4,8 +4,21 @@ require_relative "test/unit/warning"
 
 module Test
   module Unit
-    autoload :TestCase, "test/unit/testcase"
-    autoload :AutoRunner, "test/unit/autorunner"
+    LAZY_LOADER_MAPPING = {
+      :TestCase => "test/unit/testcase",
+      :AutoRunner => "test/unit/autorunner",
+    }
+
+    class << self
+      def const_missing(name)
+        if LAZY_LOADER_MAPPING.key?(name)
+          require_relative LAZY_LOADER_MAPPING[name]
+          const_get(name)
+        else
+          super
+        end
+      end
+    end
   end
 end
 

--- a/lib/test-unit.rb
+++ b/lib/test-unit.rb
@@ -4,15 +4,13 @@ require_relative "test/unit/warning"
 
 module Test
   module Unit
-    LAZY_LOADER_MAPPING = {
-      :TestCase => "test/unit/testcase",
-      :AutoRunner => "test/unit/autorunner",
-    }
-
     class << self
       def const_missing(name)
-        if LAZY_LOADER_MAPPING.key?(name)
-          require_relative LAZY_LOADER_MAPPING[name]
+        case name
+        when :AutoRunner, :TestCase
+          require_relative "test/unit/autorunner"
+          require_relative "test/unit/testcase"
+          singleton_class.remove_method(:const_missing)
           const_get(name)
         else
           super


### PR DESCRIPTION
GitHub: GH-311

This patch will reduce dependency on `$LOAD_PATH`.

More advanced replacements are out of scope for this patch, such as:

  * Changes under `test/`