### PR TITLE
Add `--version` cli option

### DIFF
--- a/lib/test/unit/autorunner.rb
+++ b/lib/test/unit/autorunner.rb
@@ -6,6 +6,7 @@ require_relative "priority"
 require_relative "attribute-matcher"
 require_relative "testcase"
 require_relative "test-suite-thread-runner"
+require_relative "version"
 
 module Test
   module Unit
@@ -206,6 +207,8 @@ module Test
 
       def options
         @options ||= OptionParser.new do |o|
+          o.version = VERSION
+
           o.banner = "Test::Unit automatic runner."
           o.banner += "\nUsage: #{$0} [options] [-- untouched arguments]"
 


### PR DESCRIPTION
Recently there have been some issues in Ruby head with binstubs. The following output is from https://github.com/ruby/ruby-dev-builder/actions/runs/15884945465/job/44794519509:

Like to add `test-unit` to the CLI test, and having a version option makes for a simple check.

```
Run ruby test_files/cli_test.rb

───── CLI Test ─────────────────
bundle    ✅   2.7.0.dev
gem       ✅   3.7.0.dev
irb       ✅   1.15.2
racc      ✅   1.8.1
rake      ✅   13.3.0
rbs       ❌   missing binstub
rdbg      ❌   missing binstub
rdoc      ✅   6.14.1

ruby 3.5.0dev (2025-06-25T17:13:11Z :detached: a1996b32a9) +PRISM [x86_64-linux]

bad exit
Error: Process completed with exit code 1.
```