### PR TITLE
test: use require_relative instead of require

### DIFF
--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -6,7 +6,7 @@
 # License:: Ruby license.
 
 require 'test/unit'
-require "testunit-test-util"
+require_relative "testunit-test-util"
 
 module Test
   module Unit

--- a/test/test-attribute-matcher.rb
+++ b/test/test-attribute-matcher.rb
@@ -1,5 +1,5 @@
 require 'test/unit'
-require 'testunit-test-util'
+require_relative 'testunit-test-util'
 
 class TestAttributeMatcher < Test::Unit::TestCase
   include TestUnitTestUtil

--- a/test/test-code-snippet.rb
+++ b/test/test-code-snippet.rb
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 require "test-unit"
-require "testunit-test-util"
+require_relative "testunit-test-util"
 
 class TestCodeSnippet < Test::Unit::TestCase
   include TestUnitTestUtil

--- a/test/test-data.rb
+++ b/test/test-data.rb
@@ -1,4 +1,4 @@
-require "testunit-test-util"
+require_relative "testunit-test-util"
 
 class TestData < Test::Unit::TestCase
   class Calc

--- a/test/test-fault-location-detector.rb
+++ b/test/test-fault-location-detector.rb
@@ -4,7 +4,7 @@
 
 require "test-unit"
 require "test/unit/fault-location-detector"
-require "testunit-test-util"
+require_relative "testunit-test-util"
 
 class TestFaultLocationDetector < Test::Unit::TestCase
   include TestUnitTestUtil

--- a/test/test-notification.rb
+++ b/test/test-notification.rb
@@ -1,5 +1,5 @@
 require 'test/unit'
-require 'testunit-test-util'
+require_relative 'testunit-test-util'
 
 class TestUnitNotification < Test::Unit::TestCase
   include TestUnitTestUtil

--- a/test/test-omission.rb
+++ b/test/test-omission.rb
@@ -1,5 +1,5 @@
 require 'test/unit'
-require 'testunit-test-util'
+require_relative 'testunit-test-util'
 
 class TestUnitOmission < Test::Unit::TestCase
   include TestUnitTestUtil

--- a/test/test-pending.rb
+++ b/test/test-pending.rb
@@ -1,5 +1,5 @@
 require 'test/unit'
-require 'testunit-test-util'
+require_relative 'testunit-test-util'
 
 class TestUnitPending < Test::Unit::TestCase
   include TestUnitTestUtil


### PR DESCRIPTION
GitHub: fix GH-311

This is a follow-up to GH-312 and the final patch to fix GH-311.
This patch will reduce dependency on `$LOAD_PATH`.

It replaces `require` with `require_relative` for internal library files in `test/`.

If you want to run tests against the installed `test-unit`, you can still use the `test/` directory like this:

This example runs tests against the installed `test-unit` version 3.6.8.

```console
$ ruby -I $(gem env home)/gems/test-unit-3.6.8/lib bin/test-unit test
```