### PR TITLE
Revert "Use require_relative instead of autoload (#313)"

### DIFF
--- a/lib/test-unit.rb
+++ b/lib/test-unit.rb
@@ -4,19 +4,8 @@ require_relative "test/unit/warning"
 
 module Test
   module Unit
-    class << self
-      def const_missing(name)
-        case name
-        when :AutoRunner, :TestCase
-          require_relative "test/unit/autorunner"
-          require_relative "test/unit/testcase"
-          singleton_class.remove_method(:const_missing)
-          const_get(name)
-        else
-          super
-        end
-      end
-    end
+    autoload :TestCase, "test/unit/testcase"
+    autoload :AutoRunner, "test/unit/autorunner"
   end
 end
 


### PR DESCRIPTION
This reverts commit 572b28afa0b387707dcb1229d2b96ba130f95f11.

GitHub: GH-320

We need to use another approach for it.

Reported by Mamoru TASAKA. Thanks!!!
