### PR TITLE
Use absolute path instead of relative path for autoload

### DIFF
--- a/lib/test-unit.rb
+++ b/lib/test-unit.rb
@@ -4,8 +4,8 @@ require_relative "test/unit/warning"
 
 module Test
   module Unit
-    autoload :TestCase, "test/unit/testcase"
-    autoload :AutoRunner, "test/unit/autorunner"
+    autoload :TestCase, "#{__dir__}/test/unit/testcase"
+    autoload :AutoRunner, "#{__dir__}/test/unit/autorunner"
   end
 end
 


### PR DESCRIPTION
GitHub: fix GH-311

This patch will reduce dependency on `$LOAD_PATH`. Using `autoload` with an absolute path means it does not depend on `$LOAD_PATH`.

`Test::Unit::TestCase` and `Test::Unit::AutoRunner` are loaded using absolute paths before these constants are referred or redefined with the open class.

Suggested by nicholas a. evans. Thanks!!!