### PR TITLE
Fix compatibility with power_assert 3.0 on older rubies

### DIFF
--- a/lib/test/unit/assertions.rb
+++ b/lib/test/unit/assertions.rb
@@ -12,6 +12,9 @@ require_relative 'diff'
 begin
   require 'power_assert'
 rescue LoadError, SyntaxError
+  if defined?(::PowerAssert)
+    ::Object.send(:remove_const, :PowerAssert)
+  end
 end
 
 module Test

--- a/lib/test/unit/util/backtracefilter.rb
+++ b/lib/test/unit/util/backtracefilter.rb
@@ -1,6 +1,9 @@
 begin
   require 'power_assert'
 rescue LoadError, SyntaxError
+  if defined?(::PowerAssert)
+    ::Object.send(:remove_const, :PowerAssert)
+  end
 end
 
 module Test


### PR DESCRIPTION
power_assert 3.0 now uses pattern matching: https://github.com/ruby/power_assert/pull/57.

This causes it to be half defined on Ruby 3.0 and older.

```
$ bundle exec ruby -Itest test/json/json_coder_test.rb
/Users/byroot/.gem/rubies/3.0.7/gems/test-unit-3.7.0/lib/test/unit/util/backtracefilter.rb:16:in `method': undefined method `start' for class `#<Class:PowerAssert>' (NameError)
	from /Users/byroot/.gem/rubies/3.0.7/gems/test-unit-3.7.0/lib/test/unit/util/backtracefilter.rb:16:in `<module:BacktraceFilter>'
	from /Users/byroot/.gem/rubies/3.0.7/gems/test-unit-3.7.0/lib/test/unit/util/backtracefilter.rb:9:in `<module:Util>'
	from /Users/byroot/.gem/rubies/3.0.7/gems/test-unit-3.7.0/lib/test/unit/util/backtracefilter.rb:8:in `<module:Unit>'
	from /Users/byroot/.gem/rubies/3.0.7/gems/test-unit-3.7.0/lib/test/unit/util/backtracefilter.rb:7:in `<module:Test>'
	from /Users/byroot/.gem/rubies/3.0.7/gems/test-unit-3.7.0/lib/test/unit/util/backtracefilter.rb:6:in `<top (required)>'
	from /Users/byroot/.gem/rubies/3.0.7/gems/test-unit-3.7.0/lib/test/unit/assertions.rb:7:in `require_relative'
	from /Users/byroot/.gem/rubies/3.0.7/gems/test-unit-3.7.0/lib/test/unit/assertions.rb:7:in `<top (required)>'
	from /Users/byroot/.gem/rubies/3.0.7/gems/test-unit-3.7.0/lib/test/unit/testcase.rb:12:in `require_relative'
	from /Users/byroot/.gem/rubies/3.0.7/gems/test-unit-3.7.0/lib/test/unit/testcase.rb:12:in `<top (required)>'
	from /Users/byroot/.gem/rubies/3.0.7/gems/test-unit-3.7.0/lib/test/unit.rb:3:in `require_relative'
	from /Users/byroot/.gem/rubies/3.0.7/gems/test-unit-3.7.0/lib/test/unit.rb:3:in `<top (required)>'
	from /Users/byroot/src/github.com/ruby/json/test/json/test_helper.rb:28:in `require'
	from /Users/byroot/src/github.com/ruby/json/test/json/test_helper.rb:28:in `<top (required)>'
	from test/json/json_coder_test.rb:4:in `require_relative'
	from test/json/json_coder_test.rb:4:in `<main>'
```

