### PR TITLE
Squash syntax warnings as well as syntax errors

### DIFF
--- a/lib/test/unit/assertions.rb
+++ b/lib/test/unit/assertions.rb
@@ -10,11 +10,14 @@ require_relative 'util/method-owner-finder'
 require_relative 'diff'
 
 begin
+  $VERBOSE, verbose = nil, $VERBOSE
   require 'power_assert'
 rescue LoadError, SyntaxError
   if defined?(::PowerAssert)
     ::Object.send(:remove_const, :PowerAssert)
   end
+ensure
+  $VERBOSE = verbose
 end
 
 module Test


### PR DESCRIPTION
test-unit always tries to load power_assert, but recent power_assert uses syntax available since ruby 3.1.
Even when test-unit squashes SyntaxError, warnings for experimental syntax or unsupported syntax are emitted before rescued, and can cause problems sometimes.