### PR TITLE
Move suppressing experimental warnings

### DIFF
--- a/lib/test/unit/assertions.rb
+++ b/lib/test/unit/assertions.rb
@@ -9,17 +9,6 @@ require_relative 'util/memory-usage'
 require_relative 'util/method-owner-finder'
 require_relative 'diff'
 
-begin
-  $VERBOSE, verbose = nil, $VERBOSE
-  require 'power_assert'
-rescue LoadError, SyntaxError
-  if defined?(::PowerAssert)
-    ::Object.send(:remove_const, :PowerAssert)
-  end
-ensure
-  $VERBOSE = verbose
-end
-
 module Test
   module Unit
 

--- a/lib/test/unit/util/backtracefilter.rb
+++ b/lib/test/unit/util/backtracefilter.rb
@@ -1,9 +1,12 @@
 begin
+  $VERBOSE, verbose = nil, $VERBOSE
   require 'power_assert'
 rescue LoadError, SyntaxError
   if defined?(::PowerAssert)
     ::Object.send(:remove_const, :PowerAssert)
   end
+ensure
+  $VERBOSE = verbose
 end
 
 module Test


### PR DESCRIPTION
Fix up #335.

`power_assert` is required in util/backtracefilter.rb too, that is required from assertions.rb, and raises `SyntaxError` twice.
As the latter file always requires the former file, the second `require` doesn't make sense.