### PR TITLE
mediator: pass test context data for process runner

### DIFF
--- a/lib/test/unit/test-suite-runner.rb
+++ b/lib/test/unit/test-suite-runner.rb
@@ -15,7 +15,7 @@ module Test
     class TestSuiteRunner
       @n_workers = Etc.respond_to?(:nprocessors) ? Etc.nprocessors : 1
       class << self
-        def run_all_tests
+        def run_all_tests(result, options)
           yield(TestRunContext.new(self))
         end
 

--- a/lib/test/unit/test-suite-thread-runner.rb
+++ b/lib/test/unit/test-suite-thread-runner.rb
@@ -12,7 +12,7 @@ module Test
   module Unit
     class TestSuiteThreadRunner < TestSuiteRunner
       class << self
-        def run_all_tests
+        def run_all_tests(result, options)
           n_workers = TestSuiteRunner.n_workers
 
           queue = Thread::Queue.new

--- a/test/testunit-test-util.rb
+++ b/test/testunit-test-util.rb
@@ -26,7 +26,7 @@ module TestUnitTestUtil
     yield(test) if block_given?
     suite = Test::Unit::TestSuite.new(test_case.name, test_case)
     suite << test
-    runner_class.run_all_tests do |run_context|
+    runner_class.run_all_tests(result, {}) do |run_context|
       suite.run(result, run_context: run_context) {}
     end
     result


### PR DESCRIPTION
This patch enables the following:

  * Allow both main and worker processes to collect the same tests
  * Emit events in main process
  * Collect results in main process

For future multi-process based parallelization support. Part of GH-235.