### PR TITLE
Add --parallel=process option

### DIFF
--- a/lib/test/unit/autorunner.rb
+++ b/lib/test/unit/autorunner.rb
@@ -415,6 +415,7 @@ module Test
 
           parallel_options = [
             :thread,
+            :process,
           ]
           o.on("--[no-]parallel=[thread]", parallel_options,
                "Runs tests in parallel",
@@ -422,6 +423,8 @@ module Test
             case parallel
             when nil, :thread
               @test_suite_runner_class = TestSuiteThreadRunner
+            when :process
+              @test_suite_runner_class = TestSuiteProcessRunner
             else
               @test_suite_runner_class = TestSuiteRunner
             end


### PR DESCRIPTION
Add support for switching the process backend. Please note that the process based runner is not yet available.

For future multi-process based parallelization support. Part of GH-235.