### PR TITLE
Introduce WorkerContext

### DIFF
--- a/lib/test/unit/testcase.rb
+++ b/lib/test/unit/testcase.rb
@@ -585,11 +585,16 @@ module Test
       # Runs the individual test method represented by this
       # instance of the fixture, collecting statistics, failures
       # and errors in result.
-      def run(result, run_context: nil)
+      def run(worker_context)
         begin
+          unless worker_context.is_a?(WorkerContext)
+            result = worker_context
+            worker_context = WorkerContext.new(nil, nil, result)
+          end
+          result = worker_context.result
           @_result = result
           instance_variables_before = instance_variables
-          @internal_data.run_context = run_context
+          @internal_data.run_context = worker_context.run_context
           @internal_data.test_started
           yield(STARTED, name)
           yield(STARTED_OBJECT, self)

--- a/lib/test/unit/testsuite.rb
+++ b/lib/test/unit/testsuite.rb
@@ -47,13 +47,14 @@ module Test
 
       # Runs the tests and/or suites contained in this
       # TestSuite.
-      def run(result, run_context: nil, &progress_block)
+      def run(worker_context, &progress_block)
+        run_context = worker_context.run_context
         if run_context
           runner_class = run_context.runner_class
         else
           runner_class = TestSuiteRunner
         end
-        runner_class.new(self).run(result, run_context: run_context) do |event, *args|
+        runner_class.new(self).run(worker_context) do |event, *args|
           case event
           when STARTED
             @start_time = Time.now

--- a/lib/test/unit/ui/testrunnermediator.rb
+++ b/lib/test/unit/ui/testrunnermediator.rb
@@ -6,6 +6,7 @@
 
 require_relative '../util/observable'
 require_relative '../testresult'
+require_relative '../worker-context'
 
 module Test
   module Unit
@@ -51,7 +52,7 @@ module Test
                   notify_listeners(RESET, @suite.size)
                   notify_listeners(STARTED, result)
 
-                  run_suite(result, run_context)
+                  run_suite(result, run_context: run_context)
                 end
               end
             end
@@ -70,11 +71,12 @@ module Test
         #
         # See GitHub#38
         #   https://github.com/test-unit/test-unit/issues/38
-        def run_suite(result=nil, run_context=nil)
+        def run_suite(result=nil, run_context: nil)
           if result.nil?
             run
           else
-            @suite.run(result, run_context: run_context, &@options[:event_listener])
+            worker_context = WorkerContext.new(nil, run_context, result)
+            @suite.run(worker_context, &@options[:event_listener])
           end
         end
 

--- a/lib/test/unit/worker-context.rb
+++ b/lib/test/unit/worker-context.rb
@@ -1,0 +1,20 @@
+#--
+#
+# Author:: Tsutomu Katsube.
+# Copyright:: Copyright (c) 2025 Tsutomu Katsube. All rights reserved.
+# License:: Ruby license.
+
+module Test
+  module Unit
+    class WorkerContext
+      attr_reader :id
+      attr_reader :run_context
+      attr_reader :result
+      def initialize(id, run_context, result)
+        @id = id
+        @run_context = run_context
+        @result = result
+      end
+    end
+  end
+end

--- a/test/test-data.rb
+++ b/test/test-data.rb
@@ -420,7 +420,8 @@ class TestData < Test::Unit::TestCase
     result = Test::Unit::TestResult.new
     test = test_case.suite
     yield(test) if block_given?
-    test.run(result) {}
+    worker_context = Test::Unit::WorkerContext.new(nil, nil, result)
+    test.run(worker_context) {}
     result
   end
 

--- a/test/test-fault-location-detector.rb
+++ b/test/test-fault-location-detector.rb
@@ -17,7 +17,8 @@ class TestFaultLocationDetector < Test::Unit::TestCase
   def run_test_case(test_case)
     suite = test_case.suite
     result = Test::Unit::TestResult.new
-    suite.run(result) {}
+    worker_context = Test::Unit::WorkerContext.new(nil, nil, result)
+    suite.run(worker_context) {}
     result.faults[0]
   end
 

--- a/test/test-test-case.rb
+++ b/test/test-test-case.rb
@@ -223,7 +223,8 @@ module Test
         check("Should have the default test", suite.tests.first.name == "default_test(Test::Unit::TestCase)")
 
         result = TestResult.new
-        suite.run(result) {}
+        worker_context = WorkerContext.new(nil, nil, result)
+        suite.run(worker_context) {}
         check("Should have had one test run", result.run_count == 1)
         check("Should have had one test failure", result.failure_count == 1)
         check("Should have had no errors", result.error_count == 0)
@@ -256,7 +257,8 @@ module Test
         check("Should have three tests", suite.size == 3)
 
         result = TestResult.new
-        suite.run(result) {}
+        worker_context = WorkerContext.new(nil, nil, result)
+        suite.run(worker_context) {}
         check("Should have had three test runs", result.run_count == 3)
         check("Should have had one test failure", result.failure_count == 1)
         check("Should have had one test error", result.error_count == 1)
@@ -318,7 +320,8 @@ module Test
         suite = tc.suite
         check("Should have one test", suite.size == 1)
         result = TestResult.new
-        suite.run(result) {}
+        worker_context = WorkerContext.new(nil, nil, result)
+        suite.run(worker_context) {}
         check("Should have had one test run", result.run_count == 1)
         check("Should have had one assertion failure", result.failure_count == 1)
         check("Should not have any assertion errors but had #{result.error_count}", result.error_count == 0)
@@ -385,8 +388,9 @@ module Test
 
         test_suite = test_case.suite
         result = TestResult.new
+        worker_context = WorkerContext.new(nil, nil, result)
         begin
-          test_suite.run(result) {}
+          test_suite.run(worker_context) {}
           check("Timeout::Error should be handled as error",
                 result.error_count == 1)
         rescue Exception
@@ -529,7 +533,8 @@ module Test
         assert_equal(["test_name", "test_name2"],
                      suite.tests.collect {|test| test.method_name})
         result = TestResult.new
-        suite.run(result) {}
+        worker_context = WorkerContext.new(nil, nil, result)
+        suite.run(worker_context) {}
         assert_equal("2 tests, 0 assertions, 0 failures, " +
                      "0 errors, 0 pendings, 0 omissions, 1 notifications",
                      result.summary)
@@ -559,7 +564,8 @@ module Test
         assert_equal(["test_without_parameter"],
                      suite.tests.collect {|test| test.method_name})
         result = TestResult.new
-        suite.run(result) {}
+        worker_context = WorkerContext.new(nil, nil, result)
+        suite.run(worker_context) {}
         assert_equal("1 tests, 1 assertions, 0 failures, " +
                      "0 errors, 0 pendings, 0 omissions, 0 notifications",
                      result.summary)
@@ -975,7 +981,9 @@ module Test
           def call_order(test_case)
             test_case.called.clear
             test_suite = test_case.suite
-            test_suite.run(TestResult.new) {}
+            result = TestResult.new
+            worker_context = WorkerContext.new(nil, nil, result)
+            test_suite.run(worker_context) {}
             test_case.called
           end
 
@@ -1102,7 +1110,9 @@ module Test
             def test_call_order
               collector = Collector::Descendant.new
               test_suite = collector.collect
-              test_suite.run(TestResult.new) {}
+              result = TestResult.new
+              worker_context = WorkerContext.new(nil, nil, result)
+              test_suite.run(worker_context) {}
               called = @parent_test_case.called
               assert_equal([
                              :startup_parent,
@@ -1123,7 +1133,8 @@ module Test
           def run_test_case(test_case)
             test_suite = test_case.suite
             result = TestResult.new
-            test_suite.run(result) {}
+            worker_context = WorkerContext.new(nil, nil, result)
+            test_suite.run(worker_context) {}
             result
           end
 

--- a/test/test-test-suite.rb
+++ b/test/test-test-suite.rb
@@ -71,7 +71,8 @@ module Test
         suite = @testcase1.suite
         tests = suite.tests.dup
         result = TestResult.new
-        suite.run(result) { |*values| progress << values }
+        worker_context = Test::Unit::WorkerContext.new(nil, nil, result)
+        suite.run(worker_context) { |*values| progress << values }
 
         assert_equal(2, result.run_count, "Should have had four test runs")
         assert_equal(1, result.failure_count, "Should have had one test failure")
@@ -95,7 +96,8 @@ module Test
         suite << @testcase2.suite
         result = TestResult.new
         progress = []
-        suite.run(result) { |*values| progress << values }
+        worker_context = Test::Unit::WorkerContext.new(nil, nil, result)
+        suite.run(worker_context) { |*values| progress << values }
 
         assert_equal(4, result.run_count, "Should have had four test runs")
         assert_equal(1, result.failure_count, "Should have had one test failure")

--- a/test/testunit-test-util.rb
+++ b/test/testunit-test-util.rb
@@ -27,7 +27,8 @@ module TestUnitTestUtil
     suite = Test::Unit::TestSuite.new(test_case.name, test_case)
     suite << test
     runner_class.run_all_tests(result, {}) do |run_context|
-      suite.run(result, run_context: run_context) {}
+      worker_context = Test::Unit::WorkerContext.new(nil, run_context, result)
+      suite.run(worker_context) {}
     end
     result
   end


### PR DESCRIPTION
Replace `result` and `run_context` parameters with a unified `WorkerContext`.

A worker id is not yet available in `Thread` based runner.

For future parallelization support. Part of GH-235.