### PR TITLE
testcase: dump/load only minimal data for marshaling

### DIFF
--- a/lib/test/unit/testcase.rb
+++ b/lib/test/unit/testcase.rb
@@ -898,8 +898,10 @@ module Test
       end
 
       def marshal_dump
-        {method_name: @method_name,
-         internal_data: @internal_data}
+        {
+          method_name: @method_name,
+          internal_data: @internal_data,
+        }
       end
 
       def marshal_load(data)
@@ -999,11 +1001,13 @@ module Test
         end
 
         def marshal_dump
-          {start_time: @start_time,
-           elapsed_time: @elapsed_time,
-           passed: @passed,
-           interrupted: @interrupted,
-           test_data_label: @test_data_label}
+          {
+            start_time: @start_time,
+            elapsed_time: @elapsed_time,
+            passed: @passed,
+            interrupted: @interrupted,
+            test_data_label: @test_data_label,
+          }
         end
 
         def marshal_load(data)


### PR DESCRIPTION
A user can freely set instance variables on a `TestCase` object, and they may include non marshalable objects such as `Proc` or `IO` objects.

In addition, dynamically data driven tests include `Proc` objects in their test data.

These can make `Marshal.dump` fail.

For future multi-process based parallelization support. Part of GH-235.