### PR TITLE
test: thread: remove needless object allocation

### DIFF
--- a/test/testunit-test-util.rb
+++ b/test/testunit-test-util.rb
@@ -26,10 +26,8 @@ module TestUnitTestUtil
     yield(test) if block_given?
     suite = Test::Unit::TestSuite.new(test_case.name, test_case)
     suite << test
-    runner_class.run_all_tests(result, {}) do |run_context|
-      worker_context = Test::Unit::WorkerContext.new(nil, run_context, result)
-      suite.run(worker_context) {}
-    end
+    worker_context = Test::Unit::WorkerContext.new(nil, nil, result)
+    suite.run(worker_context) {}
     result
   end
 


### PR DESCRIPTION
GitHub: GH-235

The `runner_class` is selected as follows:

  * Sequential: `TestSuiteRunner`
  * Thread:     `TestSuiteThreadRunner`
  * Process:    `TestSuiteRunner`

`TestSuiteThreadRunner.run_all_tests` allocates some objects (Queue, etc...), but they are needless when using the thread runner.