### PR TITLE
Remove "/" from auto generated sub test case name

### DIFF
--- a/lib/test/unit/testcase.rb
+++ b/lib/test/unit/testcase.rb
@@ -570,9 +570,13 @@ module Test
               [parent_test_case.name, name].compact.join("::")
             end
           end
-          # Give the anonymous class a unique, Base64 encoded constant name.
-          # So it becomes a named class that `Marshal` can safely dump even across processes.
-          const_set(:"TEST_#{[sub_test_case.name].pack("m").delete("\n=")}", sub_test_case)
+          # Give the anonymous class a unique, Base64 encoded constant
+          # name. So it becomes a named class that `Marshal` can
+          # safely dump even across processes.
+          #
+          # We can't use "\n", "=" and "/" in base64 as class name.
+          encoded_name = [sub_test_case.name].pack("m").delete("\n=/")
+          const_set(:"TEST_#{encoded_name}", sub_test_case)
           sub_test_case
         end
       end

--- a/test/test-test-case.rb
+++ b/test/test-test-case.rb
@@ -968,6 +968,23 @@ module Test
                          sub_test_method_names,
                        ])
         end
+
+        def test_base64_special_character
+          test_case = Class.new(TestCase) do
+          end
+          # ["array?"].pack("m") == "YXJyYXk/\n"
+          sub_test_case = test_case.sub_test_case("array?") do
+            def test_nothing
+            end
+          end
+
+          sub_test_method_names = sub_test_case.suite.tests.collect do |test|
+            test.method_name
+          end
+
+          assert_equal(["test_nothing"],
+                       sub_test_method_names)
+        end
       end
 
       class TestStartupShutdown < self


### PR DESCRIPTION
Fix GH-355

We can't use it as a class name.