### PR TITLE
process runner: improve performance on Windows

### DIFF
--- a/lib/test/unit/process-worker.rb
+++ b/lib/test/unit/process-worker.rb
@@ -41,6 +41,8 @@ suite = collector.collect(*test_paths)
 io_open = lambda do |&block|
   if Gem.win_platform?
     TCPSocket.open(remote_ip_address, remote_ip_port) do |data_socket|
+      Marshal.dump(Process.pid, data_socket)
+      data_socket.flush
       block.call(data_socket, data_socket)
     end
   else

--- a/lib/test/unit/test-suite-process-runner.rb
+++ b/lib/test/unit/test-suite-process-runner.rb
@@ -76,9 +76,7 @@ module Test
                 if Gem.win_platform?
                   # On Windows, file descriptors 3 and above cannot be passed to
                   # child processes.
-                  pid = spawn(*command_line)
-                  data_socket = tcp_server.accept
-                  workers << Worker.new(pid, data_socket, data_socket)
+                  spawn(*command_line)
                 else
                   main_to_worker_input, main_to_worker_output = IO.pipe
                   worker_to_main_input, worker_to_main_output = IO.pipe
@@ -87,6 +85,13 @@ module Test
                   main_to_worker_input.close
                   worker_to_main_output.close
                   workers << Worker.new(pid, main_to_worker_output, worker_to_main_input)
+                end
+              end
+              if Gem.win_platform?
+                n_workers.times do
+                  data_socket = tcp_server.accept
+                  pid = Marshal.load(data_socket)
+                  workers << Worker.new(pid, data_socket, data_socket)
                 end
               end
 


### PR DESCRIPTION
GitHub: follow up GH-348

This patch changes from sequential `spawn` and `accept` to batch them. Because waiting for each worker process to start one by one was slow.