### PR TITLE
Avoid relying on $! in rescued exception handling

### DIFF
--- a/lib/test/unit/fixture.rb
+++ b/lib/test/unit/fixture.rb
@@ -282,9 +282,9 @@ module Test
         return unless respond_to?(method_name, true)
         begin
           __send__(method_name, &block)
-        rescue Exception
+        rescue Exception => e
           raise unless options[:handle_exception]
-          raise unless handle_exception($!)
+          raise unless handle_exception(e)
         end
       end
 

--- a/lib/test/unit/test-suite-runner.rb
+++ b/lib/test/unit/test-suite-runner.rb
@@ -53,8 +53,8 @@ module Test
         test_case.worker_id = worker_context.id
         begin
           test_case.startup
-        rescue Exception
-          raise unless handle_exception($!, worker_context.result)
+        rescue Exception => e
+          raise unless handle_exception(e, worker_context.result)
         end
       end
 
@@ -112,8 +112,8 @@ module Test
         test_case.worker_id = worker_context.id
         begin
           test_case.shutdown
-        rescue Exception
-          raise unless handle_exception($!, worker_context.result)
+        rescue Exception => e
+          raise unless handle_exception(e, worker_context.result)
         end
       end
 

--- a/lib/test/unit/testcase.rb
+++ b/lib/test/unit/testcase.rb
@@ -634,9 +634,9 @@ module Test
                   run_test
                   run_cleanup
                   add_pass
-                rescue Exception
+                rescue Exception => e
                   @internal_data.interrupted
-                  unless handle_exception($!)
+                  unless handle_exception(e)
                     processed_exception_in_setup = true
                     raise
                   end
@@ -644,18 +644,18 @@ module Test
                 end
               end
             end
-          rescue Exception
+          rescue Exception => e
             if processed_exception_in_setup
               raise
             else
               @internal_data.interrupted
-              raise unless handle_exception($!)
+              raise unless handle_exception(e)
             end
           ensure
             begin
               run_teardown
-            rescue Exception
-              raise unless handle_exception($!)
+            rescue Exception => e
+              raise unless handle_exception(e)
             end
           end
           @internal_data.test_finished


### PR DESCRIPTION
This changes rescued exception handling to capture the exception object
explicitly instead of reading `$!` later.

`test-unit` currently has several patterns like:

```ruby
rescue Exception
  raise unless handle_exception($!)
end
```

Under `RUBY_BOX=1`, this can turn into a secondary crash because of an
upstream Ruby::Box bug where `$!` may become `nil` in this flow:
https://bugs.ruby-lang.org/issues/21823

This patch does not fix the Ruby::Box bug itself, but it makes `test-unit`
more robust by avoiding reliance on `$!` in rescued exception handling.
