### PR TITLE
test: use captured exception object explicitly

### DIFF
--- a/test/test-assertions.rb
+++ b/test/test-assertions.rb
@@ -1591,8 +1591,8 @@ EOM
                     "<true>(<TrueClass>)") do
           begin
             assert(true, true)
-          rescue ArgumentError
-            raise AssertionFailedError, $!.message
+          rescue ArgumentError => e
+            raise AssertionFailedError, e.message
           end
         end
       end
@@ -1601,8 +1601,8 @@ EOM
         check_fail("wrong number of arguments (0 for 1..2)") do
           begin
             assert
-          rescue ArgumentError
-            raise AssertionFailedError, $!.message
+          rescue ArgumentError => e
+            raise AssertionFailedError, e.message
           end
         end
       end
@@ -1680,8 +1680,8 @@ MESSAGE
                 "<false>(<FalseClass>)") do
             begin
               refute(true, false)
-            rescue ArgumentError
-              raise AssertionFailedError, $!.message
+            rescue ArgumentError => e
+              raise AssertionFailedError, e.message
             end
           end
         end

--- a/test/test-test-case.rb
+++ b/test/test-test-case.rb
@@ -373,8 +373,8 @@ module Test
         begin
           test.run(TestResult.new) {}
           check("Should not be reached", false)
-        rescue Exception
-          check("Interrupt exception should be re-raised", $!.class == Interrupt)
+        rescue Exception => e
+          check("Interrupt exception should be re-raised", e.class == Interrupt)
         end
       end
 


### PR DESCRIPTION
When Ruby Box is enabled (`RUBY_BOX=1`), $! inside rescue does not change after the first exception.

https://bugs.ruby-lang.org/issues/21991