### PR TITLE
Prepend load paths instead of appending them

### DIFF
--- a/lib/test/unit/autorunner.rb
+++ b/lib/test/unit/autorunner.rb
@@ -363,7 +363,7 @@ module Test
           end
 
           o.on("-I", "--load-path=DIR[#{File::PATH_SEPARATOR}DIR...]",
-               "Appends directory list to $LOAD_PATH.") do |dirs|
+               "Prepends directory list to $LOAD_PATH.") do |dirs|
             load_paths = dirs.split(File::PATH_SEPARATOR)
             $LOAD_PATH.unshift(*load_paths)
             @load_paths.unshift(*load_paths)

--- a/lib/test/unit/autorunner.rb
+++ b/lib/test/unit/autorunner.rb
@@ -365,8 +365,8 @@ module Test
           o.on("-I", "--load-path=DIR[#{File::PATH_SEPARATOR}DIR...]",
                "Appends directory list to $LOAD_PATH.") do |dirs|
             load_paths = dirs.split(File::PATH_SEPARATOR)
-            $LOAD_PATH.concat(load_paths)
-            @load_paths.concat(load_paths)
+            $LOAD_PATH.unshift(*load_paths)
+            @load_paths.unshift(*load_paths)
           end
 
           color_schemes = ColorScheme.all

--- a/lib/test/unit/autorunner.rb
+++ b/lib/test/unit/autorunner.rb
@@ -199,6 +199,7 @@ module Test
         begin
           args.unshift(*@default_arguments)
           options.order!(args) {|arg| add_test_path(arg)}
+          $LOAD_PATH.unshift(*@load_paths)
         rescue OptionParser::ParseError => e
           puts e
           puts options
@@ -364,9 +365,7 @@ module Test
 
           o.on("-I", "--load-path=DIR[#{File::PATH_SEPARATOR}DIR...]",
                "Prepends directory list to $LOAD_PATH.") do |dirs|
-            load_paths = dirs.split(File::PATH_SEPARATOR)
-            $LOAD_PATH.unshift(*load_paths)
-            @load_paths.unshift(*load_paths)
+            @load_paths.concat(dirs.split(File::PATH_SEPARATOR))
           end
 
           color_schemes = ColorScheme.all

--- a/lib/test/unit/process-worker.rb
+++ b/lib/test/unit/process-worker.rb
@@ -9,7 +9,7 @@ require "socket"
 
 parser = OptionParser.new
 parser.on("--load-path=PATH") do |path|
-  $LOAD_PATH << path
+  $LOAD_PATH.unshift(path)
 end
 base_directory = nil
 parser.on("--base-directory=PATH") do |path|

--- a/lib/test/unit/process-worker.rb
+++ b/lib/test/unit/process-worker.rb
@@ -8,8 +8,9 @@ require "optparse"
 require "socket"
 
 parser = OptionParser.new
+load_paths = []
 parser.on("--load-path=PATH") do |path|
-  $LOAD_PATH.unshift(path)
+  load_paths << path
 end
 base_directory = nil
 parser.on("--base-directory=PATH") do |path|
@@ -28,6 +29,7 @@ parser.on("--ip-port=PORT", Integer) do |port|
   remote_ip_port = port
 end
 test_paths = parser.parse!
+$LOAD_PATH.unshift(*load_paths)
 
 require_relative "../unit"
 require_relative "collector/load"


### PR DESCRIPTION
GitHub: ruby/rubygems#9572

Because we want to load the library under development before the system library.