### PR TITLE
Add test_result?

### DIFF
--- a/lib/test/unit/process-test-result.rb
+++ b/lib/test/unit/process-test-result.rb
@@ -11,6 +11,10 @@ module Test
         @output = output
       end
 
+      def test_result?
+        true
+      end
+
       def add_run
         send_result(__method__)
       end

--- a/lib/test/unit/sub-test-result.rb
+++ b/lib/test/unit/sub-test-result.rb
@@ -14,6 +14,10 @@ module Test
         @stop_tag = nil
       end
 
+      def test_result?
+        true
+      end
+
       def add_run(result=self)
         @parent_test_result.add_run(result)
       end

--- a/lib/test/unit/testcase.rb
+++ b/lib/test/unit/testcase.rb
@@ -618,7 +618,7 @@ module Test
       # and errors in result.
       def run(worker_context)
         begin
-          unless worker_context.is_a?(WorkerContext)
+          if worker_context.test_result?
             result = worker_context
             worker_context = WorkerContext.new(nil, nil, result)
           end

--- a/lib/test/unit/testresult.rb
+++ b/lib/test/unit/testresult.rb
@@ -50,6 +50,10 @@ module Test
         initialize_containers
       end
 
+      def test_result?
+        true
+      end
+
       # Records a test run.
       def add_run(result=self)
         @run_count += 1

--- a/lib/test/unit/worker-context.rb
+++ b/lib/test/unit/worker-context.rb
@@ -15,6 +15,10 @@ module Test
         @run_context = run_context
         @result = result
       end
+
+      def test_result?
+        false
+      end
     end
   end
 end


### PR DESCRIPTION
We can't use `is_a?(WorkerContext)` when we load multiple test-unit by Ruby Box.