### PR TITLE
Add :message in require_failed_infos

### DIFF
--- a/lib/test/unit/collector/load.rb
+++ b/lib/test/unit/collector/load.rb
@@ -181,7 +181,6 @@ module Test
               normalized_path = path.to_s.gsub(/[^a-z0-9\_]+/i, '_')
               normalized_path = normalized_path.gsub(/\A_+/, '')
               exception = info[:exception]
-              message = info[:message]
               if exception
                 define_method("test_require_#{normalized_path}") do
                   raise(exception.class,
@@ -189,6 +188,7 @@ module Test
                         exception.backtrace)
                 end
               else
+                message = info[:message]
                 define_method("test_require_#{normalized_path}") do
                   raise("failed to load <#{path}>: #{message}")
                 end

--- a/lib/test/unit/collector/load.rb
+++ b/lib/test/unit/collector/load.rb
@@ -181,10 +181,17 @@ module Test
               normalized_path = path.to_s.gsub(/[^a-z0-9\_]+/i, '_')
               normalized_path = normalized_path.gsub(/\A_+/, '')
               exception = info[:exception]
-              define_method("test_require_#{normalized_path}") do
-                raise(exception.class,
-                      "failed to load <#{path}>: #{exception.message}",
-                      exception.backtrace)
+              message = info[:message]
+              if exception
+                define_method("test_require_#{normalized_path}") do
+                  raise(exception.class,
+                        "failed to load <#{path}>: #{exception.message}",
+                        exception.backtrace)
+                end
+              else
+                define_method("test_require_#{normalized_path}") do
+                  raise("failed to load <#{path}>: #{message}")
+                end
               end
             end
 


### PR DESCRIPTION
To avoid unnecessary exception objects.