### PR TITLE
Use #suite? instead of .test_suite?

### DIFF
--- a/lib/test/unit/collector.rb
+++ b/lib/test/unit/collector.rb
@@ -16,7 +16,7 @@ module Test
 
       def add_suite(destination, suite)
         to_delete = suite.tests.find_all do |test|
-          !test.class.test_suite? and !include?(test)
+          !test.suite? and !include?(test)
         end
         suite.delete_tests(to_delete)
         destination << suite unless suite.empty?
@@ -81,7 +81,7 @@ module Test
         ractor_suites = []
         ractor_tests = []
         suite.tests.each do |test|
-          if test.class.test_suite?
+          if test.suite?
             ractor_suites.concat(extract_ractor_tests(test))
           else
             next unless test[:ractor]

--- a/lib/test/unit/process-worker.rb
+++ b/lib/test/unit/process-worker.rb
@@ -70,7 +70,7 @@ io_open.call do |data_input, data_output|
       Marshal.dump({status: :event, event_name: event_name, args: args}, data_output)
       data_output.flush
     end
-    if test.is_a?(Test::Unit::TestSuite)
+    if test.suite?
       test_suite = test
     else
       test_suite = Test::Unit::TestSuite.new(test.class.name, test.class)

--- a/lib/test/unit/test-suite-process-runner.rb
+++ b/lib/test/unit/test-suite-process-runner.rb
@@ -192,7 +192,7 @@ module Test
           run_context.test_names << test_suite.name
         else
           test_suite.tests.each do |test|
-            if test.is_a?(TestSuite)
+            if test.suite?
               run_tests_recursive(test, worker_context, &progress_block)
             else
               run_context.test_names << test.name

--- a/lib/test/unit/test-suite-thread-runner.rb
+++ b/lib/test/unit/test-suite-thread-runner.rb
@@ -73,7 +73,7 @@ module Test
           run_context.queue << task
         else
           test_suite.tests.each do |test|
-            if test.is_a?(TestSuite)
+            if test.suite?
               run_tests_recursive(test, worker_context, &progress_block)
             elsif test_suite.parallel_safe?
               task = lambda do |stop_tag, worker_id|

--- a/lib/test/unit/testcase.rb
+++ b/lib/test/unit/testcase.rb
@@ -150,10 +150,6 @@ module Test
           true
         end
 
-        def test_suite?
-          false
-        end
-
         def inherited(sub_class) # :nodoc:
           DESCENDANTS << sub_class
           super
@@ -597,6 +593,10 @@ module Test
       # Assigns test data to the test. It is used in internal.
       def assign_test_data(label, data) # :nodoc:
         @internal_data.assign_test_data(label, data)
+      end
+
+      def suite?
+        false
       end
 
       # Returns the test is valid test. It is used in internal.

--- a/lib/test/unit/testsuite.rb
+++ b/lib/test/unit/testsuite.rb
@@ -19,12 +19,6 @@ module Test
     # has a suite method as simply providing a way to get a
     # meaningful TestSuite instance.
     class TestSuite
-      class << self
-        def test_suite?
-          true
-        end
-      end
-
       attr_reader :name, :tests, :test_case, :start_time, :elapsed_time
 
       # Test suite that has higher priority is ran prior to
@@ -49,7 +43,7 @@ module Test
       def find(name)
         return self if @name == name
         @tests.each do |test|
-          if test.is_a?(self.class)
+          if test.suite?
             t = test.find(name)
             return t if t
           else
@@ -69,6 +63,10 @@ module Test
         return true if @test_case.method(:startup).owner != TestCase.singleton_class
         return true if @test_case.method(:shutdown).owner != TestCase.singleton_class
         false
+      end
+
+      def suite?
+        true
       end
 
       # Runs the tests and/or suites contained in this


### PR DESCRIPTION
The caller can simply to `test.suite?`.

Q&A: Don't we use #test_suite? ? No, instance methods with "test" prefix are recognized as tests.