### PR TITLE
Add test_case?

### DIFF
--- a/lib/test/unit/testcase.rb
+++ b/lib/test/unit/testcase.rb
@@ -154,6 +154,10 @@ module Test
           false
         end
 
+        def test_case?
+          true
+        end
+
         def inherited(sub_class) # :nodoc:
           DESCENDANTS << sub_class
           super

--- a/lib/test/unit/testsuite.rb
+++ b/lib/test/unit/testsuite.rb
@@ -23,6 +23,10 @@ module Test
         def test_suite?
           true
         end
+
+        def test_case?
+          false
+        end
       end
 
       attr_reader :name, :tests, :test_case, :start_time, :elapsed_time


### PR DESCRIPTION
We can't use `is_a?(TestCase)`/`=== TestSuite` when we use load multiple test-unit by Ruby Box.

This method is needed to identify `TestCase`, `TestSuite`, and other types.